### PR TITLE
Add ec2 role credentials

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,11 +2,12 @@
 
 
 [[projects]]
-  digest = "1:222804d5fb195251b4c21f704e39672590154664475bc69381c545a9ecfc39b2"
+  branch = "master"
+  digest = "1:a12cb904f8fb247c1e8ffb36a57607d286319acd3d734a5b1d59370883a19117"
   name = "github.com/Cox-Automotive/alks-go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "4a87d235c4553dba29ddd235db623425c68aa851"
+  revision = "b8d8670a4cf3cefd352e73dc532f22880085dede"
 
 [[projects]]
   digest = "1:672133929e2786ef49ada5ea7476fa154e251d04da8fa79ae0be0694562ef94e"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -245,6 +245,7 @@
     "github.com/Cox-Automotive/alks-go",
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/credentials",
+    "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/sts",
     "github.com/hashicorp/terraform/helper/resource",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,3 +28,6 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/aws/aws-sdk-go"

--- a/config.go
+++ b/config.go
@@ -13,8 +13,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
+// Config stores ALKS configuration and credentials
 type Config struct {
-	Url           string
+	URL           string
 	AccessKey     string
 	SecretKey     string
 	Token         string
@@ -43,6 +44,7 @@ func getCredentials(c *Config) *credentials.Credentials {
 	return credentials.NewChainCredentials(providers)
 }
 
+// Client returns a properly configured ALKS client or an appropriate error if initialization fails
 func (c *Config) Client() (*alks.Client, error) {
 	log.Println("[DEBUG] Validting STS credentials")
 
@@ -78,7 +80,7 @@ providing credentials for the ALKS Provider`)
 	}
 
 	// got good creds, create alks sts client
-	client, err := alks.NewSTSClient(c.Url, cp.AccessKeyID, cp.SecretAccessKey, cp.SessionToken)
+	client, err := alks.NewSTSClient(c.URL, cp.AccessKeyID, cp.SecretAccessKey, cp.SessionToken)
 
 	if err != nil {
 		return nil, err

--- a/config.go
+++ b/config.go
@@ -3,12 +3,14 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/Cox-Automotive/alks-go"
+	"log"
+
+	alks "github.com/Cox-Automotive/alks-go"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"log"
 )
 
 type Config struct {
@@ -21,6 +23,9 @@ type Config struct {
 }
 
 func getCredentials(c *Config) *credentials.Credentials {
+	// Follow the  same priority as the AWS Terraform Provider
+	// https://www.terraform.io/docs/providers/aws/#authentication
+
 	providers := []credentials.Provider{
 		&credentials.StaticProvider{Value: credentials.Value{
 			AccessKeyID:     c.AccessKey,
@@ -32,6 +37,7 @@ func getCredentials(c *Config) *credentials.Credentials {
 			Filename: c.CredsFilename,
 			Profile:  c.Profile,
 		},
+		&ec2rolecreds.EC2RoleProvider{},
 	}
 
 	return credentials.NewChainCredentials(providers)

--- a/config.go
+++ b/config.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+
 	alks "github.com/Cox-Automotive/alks-go"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -27,6 +29,9 @@ func getCredentials(c *Config) *credentials.Credentials {
 	// Follow the  same priority as the AWS Terraform Provider
 	// https://www.terraform.io/docs/providers/aws/#authentication
 
+	// needed for the EC2MetaData service
+	sess := session.Must(session.NewSession())
+
 	providers := []credentials.Provider{
 		&credentials.StaticProvider{Value: credentials.Value{
 			AccessKeyID:     c.AccessKey,
@@ -38,7 +43,9 @@ func getCredentials(c *Config) *credentials.Credentials {
 			Filename: c.CredsFilename,
 			Profile:  c.Profile,
 		},
-		&ec2rolecreds.EC2RoleProvider{},
+		&ec2rolecreds.EC2RoleProvider{
+			Client: ec2metadata.New(sess),
+		},
 	}
 
 	return credentials.NewChainCredentials(providers)

--- a/provider.go
+++ b/provider.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/mitchellh/go-homedir"
+	homedir "github.com/mitchellh/go-homedir"
 )
 
 // Provider returns a terraform.ResourceProvider.
@@ -72,7 +72,7 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		Url:       d.Get("url").(string),
+		URL:       d.Get("url").(string),
 		AccessKey: d.Get("access_key").(string),
 		SecretKey: d.Get("secret_key").(string),
 		Token:     d.Get("token").(string),

--- a/resource_alks_iamrole.go
+++ b/resource_alks_iamrole.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Cox-Automotive/alks-go"
+	alks "github.com/Cox-Automotive/alks-go"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -95,7 +95,7 @@ func resourceAlksIamRoleCreate(d *schema.ResourceData, meta interface{}) error {
 	var incDefPol = d.Get("include_default_policies").(bool)
 
 	client := meta.(*alks.Client)
-	resp, err := client.CreateIamRole(roleName, roleType, incDefPol)
+	resp, err := client.CreateIamRole(roleName, roleType, incDefPol, false)
 
 	if err != nil {
 		return err
@@ -123,7 +123,7 @@ func resourceAlksIamTrustRoleCreate(d *schema.ResourceData, meta interface{}) er
 	var resp *alks.IamRoleResponse
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		var err error
-		resp, err = client.CreateIamTrustRole(roleName, roleType, trustArn)
+		resp, err = client.CreateIamTrustRole(roleName, roleType, trustArn, false)
 		if err != nil {
 			return resource.RetryableError(err)
 		}

--- a/resource_alks_iamrole_test.go
+++ b/resource_alks_iamrole_test.go
@@ -5,10 +5,9 @@ import (
 	"log"
 	"testing"
 
+	alks "github.com/Cox-Automotive/alks-go"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-
-	"github.com/Cox-Automotive/alks-go"
 )
 
 func TestAccAlksIamRole_Basic(t *testing.T) {
@@ -118,7 +117,7 @@ func testAccCheckAlksIamRoleAttributes(role *alks.IamRoleResponse) resource.Test
 	}
 }
 
-const testAccCheckAlksIamRoleConfig_basic = `
+const testAccCheckAlksIamRoleConfigBasic = `
 resource "alks_iamrole" "foo" {
     name = "bar420"
     type = "Amazon EC2"
@@ -126,7 +125,7 @@ resource "alks_iamrole" "foo" {
 }
 `
 
-const testAccCheckAlksIamTrustRoleConfig_basic = `
+const testAccCheckAlksIamTrustRoleConfigBasic = `
 resource "alks_iamrole" "foo" {
 	name = "foo"
 	type = "Amazon EC2"

--- a/resource_alks_iamrole_test.go
+++ b/resource_alks_iamrole_test.go
@@ -19,7 +19,7 @@ func TestAccAlksIamRole_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckAlksIamRoleDestroy(&resp),
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckAlksIamRoleConfig_basic,
+				Config: testAccCheckAlksIamRoleConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					// testAccCheckAlksIamRoleExists("bar420", &resp),
 					// testAccCheckAlksIamRoleAttributes(&resp),
@@ -44,7 +44,7 @@ func TestAccAlksIamTrustRole_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckAlksIamRoleDestroy(&resp),
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckAlksIamTrustRoleConfig_basic,
+				Config: testAccCheckAlksIamTrustRoleConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"alks_iamtrustrole.bar", "name", "bar"),

--- a/vendor/github.com/Cox-Automotive/alks-go/iam_role.go
+++ b/vendor/github.com/Cox-Automotive/alks-go/iam_role.go
@@ -13,13 +13,15 @@ type IamRoleRequest struct {
 	RoleName   string `json:"roleName"`
 	RoleType   string `json:"roleType"`
 	IncDefPols int    `json:"includeDefaultPolicy"`
+	AlksAccess bool   `json:"enableAlksAccess"`
 }
 
 // IamTrustRoleRequest is used to represent a new IAM Trust Role request.
 type IamTrustRoleRequest struct {
-	RoleName string `json:"roleName"`
-	RoleType string `json:"roleType"`
-	TrustArn string `json:"trustArn"`
+	RoleName   string `json:"roleName"`
+	RoleType   string `json:"roleType"`
+	TrustArn   string `json:"trustArn"`
+	AlksAccess bool   `json:"enableAlksAccess"`
 }
 
 // IamRoleResponse is used to represent a a IAM Role.
@@ -55,10 +57,10 @@ type DeleteRoleResponse struct {
 
 // CreateIamRole will create a new IAM role on AWS. If no error is returned
 // then you will receive a IamRoleResponse object representing the new role.
-func (c *Client) CreateIamRole(roleName string, roleType string, includeDefaultPolicies bool) (*IamRoleResponse, error) {
+func (c *Client) CreateIamRole(roleName string, roleType string, includeDefaultPolicies, enableAlksAccess bool) (*IamRoleResponse, error) {
 	log.Printf("[INFO] Creating IAM role: %s", roleName)
 
-	var include int = 0
+	var include int
 	if includeDefaultPolicies {
 		include = 1
 	}
@@ -67,6 +69,7 @@ func (c *Client) CreateIamRole(roleName string, roleType string, includeDefaultP
 		roleName,
 		roleType,
 		include,
+		enableAlksAccess,
 	}
 
 	var b []byte
@@ -113,13 +116,14 @@ func (c *Client) CreateIamRole(roleName string, roleType string, includeDefaultP
 
 // CreateIamTrustRole will create a new IAM trust role on AWS. If no error is returned
 // then you will receive a IamRoleResponse object representing the new role.
-func (c *Client) CreateIamTrustRole(roleName string, roleType string, trustArn string) (*IamRoleResponse, error) {
+func (c *Client) CreateIamTrustRole(roleName string, roleType string, trustArn string, enableAlksAccess bool) (*IamRoleResponse, error) {
 	log.Printf("[INFO] Creating IAM trust role: %s", roleName)
 
 	iam := IamTrustRoleRequest{
 		roleName,
 		roleType,
 		trustArn,
+		enableAlksAccess,
 	}
 
 	var b []byte


### PR DESCRIPTION
This code adds support for the `Ec2RoleProvider` in the ALKS credential provider chain, closing #31.