### PR TITLE
Add assume role

### DIFF
--- a/config.go
+++ b/config.go
@@ -99,7 +99,7 @@ providing credentials for the ALKS Provider`)
 
 		cp, cpErr = arCreds.Get()
 		if cpErr != nil {
-			return nil, fmt.Errorf("The role %q cannot be assumed. Please verify the role ARN and your base AWS credentials", c.AssumeRole.RoleARN)
+			return nil, fmt.Errorf("The role %q cannot be assumed. Please verify the role ARN, role policies and your base AWS credentials", c.AssumeRole.RoleARN)
 		}
 
 		stsconn = sts.New(sess, &aws.Config{

--- a/provider.go
+++ b/provider.go
@@ -59,6 +59,7 @@ func Provider() terraform.ResourceProvider {
 				Description: "The path to the shared credentials file. If not set this defaults to ~/.aws/credentials.",
 				DefaultFunc: schema.EnvDefaultFunc("AWS_SHARED_CREDENTIALS_FILE", nil),
 			},
+			"assume_role": assumeRoleSchema(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -70,6 +71,38 @@ func Provider() terraform.ResourceProvider {
 	}
 }
 
+func assumeRoleSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"role_arn": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "(Required) Role ARN to assume before calling ALKS",
+				},
+				"session_name": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "(Optional) Session name to use when making the AssumeRole call.  See AWS SDK for more details.",
+				},
+				"external_id": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "(Optional) The external ID to use when making the AssumeRole call. See AWS SDK for more details.",
+				},
+				"policy": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "(Optional) Additional policy restrictions to apply to the result STS session.  See AWS SDK for more details.",
+				},
+			},
+		},
+	}
+}
+
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		URL:       d.Get("url").(string),
@@ -77,6 +110,15 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		SecretKey: d.Get("secret_key").(string),
 		Token:     d.Get("token").(string),
 		Profile:   d.Get("profile").(string),
+	}
+
+	assumeRoleList := d.Get("assume_role").(*schema.Set).List()
+	if len(assumeRoleList) == 1 {
+		assumeRole := assumeRoleList[0].(map[string]interface{})
+		config.AssumeRole.RoleARN = assumeRole["role_arn"].(string)
+		config.AssumeRole.SessionName = assumeRole["session_name"].(string)
+		config.AssumeRole.ExternalID = assumeRole["external_id"].(string)
+		config.AssumeRole.Policy = assumeRole["policy"].(string)
 	}
 
 	// Set CredsFilename, expanding home directory

--- a/resource_alks_iamrole.go
+++ b/resource_alks_iamrole.go
@@ -108,11 +108,7 @@ func resourceAlksIamRoleCreate(d *schema.ResourceData, meta interface{}) error {
 	var enableAlksAccess = d.Get("enable_alks_access").(bool)
 
 	client := meta.(*alks.Client)
-<<<<<<< HEAD
-	resp, err := client.CreateIamRole(roleName, roleType, incDefPol, false)
-=======
 	resp, err := client.CreateIamRole(roleName, roleType, incDefPol, enableAlksAccess)
->>>>>>> master
 
 	if err != nil {
 		return err
@@ -141,11 +137,7 @@ func resourceAlksIamTrustRoleCreate(d *schema.ResourceData, meta interface{}) er
 	var resp *alks.IamRoleResponse
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		var err error
-<<<<<<< HEAD
-		resp, err = client.CreateIamTrustRole(roleName, roleType, trustArn, false)
-=======
 		resp, err = client.CreateIamTrustRole(roleName, roleType, trustArn, enableAlksAccess)
->>>>>>> master
 		if err != nil {
 			return resource.RetryableError(err)
 		}


### PR DESCRIPTION
Adds support to ALKS for the `assume_role` provider, closes #27.