### PR TITLE
Update user agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,34 +20,34 @@ install:
 release:
 	mkdir -p release
 
-	GOOS=darwin GOARCH=amd64 go build -o release/terraform-provider-alks_v$(TRAVIS_TAG) $(package)
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.versionNumber=$(TRAVIS_TAG)" -o release/terraform-provider-alks_v$(TRAVIS_TAG) $(package)
 	chmod +x release/terraform-provider-alks_v$(TRAVIS_TAG)
 	tar -cvzf release/terraform-provider-alks-darwin-amd64.tar.gz -C release/ terraform-provider-alks_v$(TRAVIS_TAG)
 
-	GOOS=freebsd GOARCH=386 go build -o release/terraform-provider-alks_v$(TRAVIS_TAG) $(package)
+	GOOS=freebsd GOARCH=386 go build -ldflags "-X main.versionNumber=$(TRAVIS_TAG)" -o release/terraform-provider-alks_v$(TRAVIS_TAG) $(package)
 	chmod +x release/terraform-provider-alks_v$(TRAVIS_TAG)
 	tar -cvzf release/terraform-provider-alks-freebsd-386.tar.gz -C release/ terraform-provider-alks_v$(TRAVIS_TAG)
 
-	GOOS=freebsd GOARCH=amd64 go build -o release/terraform-provider-alks_v$(TRAVIS_TAG) $(package)
+	GOOS=freebsd GOARCH=amd64 go build -ldflags "-X main.versionNumber=$(TRAVIS_TAG)" -o release/terraform-provider-alks_v$(TRAVIS_TAG) $(package)
 	chmod +x release/terraform-provider-alks_v$(TRAVIS_TAG)
 	tar -cvzf release/terraform-provider-alks-freebsd-amd64.tar.gz -C release/ terraform-provider-alks_v$(TRAVIS_TAG)
 
-	GOOS=linux GOARCH=386 go build -o release/terraform-provider-alks_v$(TRAVIS_TAG) $(package)
+	GOOS=linux GOARCH=386 go build -ldflags "-X main.versionNumber=$(TRAVIS_TAG)" -o release/terraform-provider-alks_v$(TRAVIS_TAG) $(package)
 	chmod +x release/terraform-provider-alks_v$(TRAVIS_TAG)
 	tar -cvzf release/terraform-provider-alks-linux-386.tar.gz -C release/ terraform-provider-alks_v$(TRAVIS_TAG)
 
-	GOOS=linux GOARCH=amd64 go build -o release/terraform-provider-alks_v$(TRAVIS_TAG) $(package)
+	GOOS=linux GOARCH=amd64 go build -ldflags "-X main.versionNumber=$(TRAVIS_TAG)" -o release/terraform-provider-alks_v$(TRAVIS_TAG) $(package)
 	chmod +x release/terraform-provider-alks_v$(TRAVIS_TAG)
 	tar -cvzf release/terraform-provider-alks-linux-amd64.tar.gz -C release/ terraform-provider-alks_v$(TRAVIS_TAG)
 
-	GOOS=solaris GOARCH=amd64 go build -o release/terraform-provider-alks_v$(TRAVIS_TAG) $(package)
+	GOOS=solaris GOARCH=amd64 go build -ldflags "-X main.versionNumber=$(TRAVIS_TAG)" -o release/terraform-provider-alks_v$(TRAVIS_TAG) $(package)
 	chmod +x release/terraform-provider-alks_v$(TRAVIS_TAG)
 	tar -cvzf release/terraform-provider-alks-solaris-amd64.tar.gz -C release/ terraform-provider-alks_v$(TRAVIS_TAG)
 
-	GOOS=windows GOARCH=386 go build -o release/terraform-provider-alks_v$(TRAVIS_TAG).exe $(package)
+	GOOS=windows GOARCH=386 go build -ldflags "-X main.versionNumber=$(TRAVIS_TAG)" -o release/terraform-provider-alks_v$(TRAVIS_TAG).exe $(package)
 	zip release/terraform-provider-alks-windows-386.zip release/terraform-provider-alks_v$(TRAVIS_TAG).exe
 	
-	GOOS=windows GOARCH=amd64 go build -o release/terraform-provider-alks_v$(TRAVIS_TAG).exe $(package)
+	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.versionNumber=$(TRAVIS_TAG)" -o release/terraform-provider-alks_v$(TRAVIS_TAG).exe $(package)
 	zip release/terraform-provider-alks-windows-amd64.zip release/terraform-provider-alks_v$(TRAVIS_TAG).exe
 
 	rm release/terraform-provider-alks_v$(TRAVIS_TAG).exe

--- a/config.go
+++ b/config.go
@@ -21,6 +21,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
+// Version number, to be injected at link time
+// to set, add `-ldflags "-X main.versionNumber=1.2.3"` to the go build command
+var versionNumber string
+
 // Config stores ALKS configuration and credentials
 type Config struct {
 	URL           string
@@ -148,7 +152,17 @@ providing credentials for the ALKS Provider`)
 		return nil, err
 	}
 
+	client.SetUserAgent(fmt.Sprintf("alks-terraform-provider-%s", getPluginVersion()))
+
 	log.Println("[INFO] ALKS Client configured")
 
 	return client, nil
+}
+
+func getPluginVersion() string {
+	if versionNumber != "" {
+		return versionNumber
+	}
+
+	return "unknown"
 }


### PR DESCRIPTION
Closes #52 

This PR updates the TF provider to identify itself via the User-Agent HTTP header.  It also adds a bit of linker magic to inject the current TF version number info that header.