### PR TITLE
Support getting credentials from session

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ import (
 
 	alks "github.com/Cox-Automotive/alks-go"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -25,6 +26,9 @@ import (
 // Version number, to be injected at link time
 // to set, add `-ldflags "-X main.versionNumber=1.2.3"` to the go build command
 var versionNumber string
+var ErrNoValidCredentialSources = errors.New(`No valid credential sources found for ALKS Provider.
+Please see https://github.com/Cox-Automotive/terraform-provider-alks#authentication for more information on
+providing credentials for the ALKS Provider`)
 
 // Config stores ALKS configuration and credentials
 type Config struct {
@@ -82,6 +86,41 @@ func getCredentials(c *Config) *credentials.Credentials {
 	return credentials.NewChainCredentials(providers)
 }
 
+func getCredentialsFromSession(c *Config) (*credentials.Credentials, error) {
+	var sess *session.Session
+	var err error
+	if c.Profile == "" {
+		sess, err = session.NewSession()
+		if err != nil {
+			return nil, ErrNoValidCredentialSources
+		}
+	} else {
+		options := &session.Options{
+			Config: aws.Config{
+				HTTPClient: cleanhttp.DefaultClient(),
+				MaxRetries: aws.Int(0),
+				Region:     aws.String("us-east-1"),
+			},
+		}
+		options.Profile = c.Profile
+		options.SharedConfigState = session.SharedConfigEnable
+
+		sess, err = session.NewSessionWithOptions(*options)
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
+				return nil, ErrNoValidCredentialSources
+			}
+			return nil, fmt.Errorf("Error creating AWS session: %s", err)
+		}
+	}
+	creds := sess.Config.Credentials
+	_, err = sess.Config.Credentials.Get()
+	if err != nil {
+		return nil, ErrNoValidCredentialSources
+	}
+	return creds, nil
+}
+
 // Client returns a properly configured ALKS client or an appropriate error if initialization fails
 func (c *Config) Client() (*alks.Client, error) {
 	log.Println("[DEBUG] Validting STS credentials")
@@ -92,9 +131,17 @@ func (c *Config) Client() (*alks.Client, error) {
 
 	// validate we have credentials
 	if cpErr != nil {
-		return nil, errors.New(`No valid credential sources found for ALKS Provider.
-Please see https://github.com/Cox-Automotive/terraform-provider-alks#authentication for more information on
-providing credentials for the ALKS Provider`)
+		if awsErr, ok := cpErr.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
+			var err error
+			creds, err = getCredentialsFromSession(c)
+			if err != nil {
+				return nil, err
+			}
+			cp, cpErr = creds.Get()
+		}
+	}
+	if cpErr != nil {
+		return nil, ErrNoValidCredentialSources
 	}
 
 	// create a new session to test credentails


### PR DESCRIPTION
Most of the implementation is copied from terraform-provider-aws:

https://github.com/hashicorp/aws-sdk-go-base/blob/f3803c633e9e5e48868e7a2c3ed69eb05dc95f5f/awsauth.go

Which is derived from some work I did a while back:

https://github.com/terraform-providers/terraform-provider-aws/pull/2883
https://github.com/terraform-providers/terraform-provider-aws/issues/1184

This allows terraform to use the default credential chain as a fallback -- which enables support for things like setting AWS_PROFILE as an environment variable.  Furthermore, I did this because I just switched myself to `credential_process`.

Tested with:

~/.aws/credentials (empty file)

~/.aws/config
```
[profile awsmarvendeploynp]
credential_process = /usr/local/bin/ach awsmarvendeploynp
```

my credential_process script:
```
#!/usr/bin/env bash

# careful, I use gnu everything on my mac
# see https://www.topbug.net/blog/2013/04/14/install-and-use-gnu-command-line-tools-in-mac-os-x/
TOP=$(cd $(dirname $(readlink -f ${BASH_SOURCE[0]}))/..; pwd)
LOCK=$TOP/cache/lock

cacheget() {
    local file=$1
    local timeout=$2
    shift 2

    if [ -f $file ]; then
        local age=$(stat --format='%Y' $file)
        local now=$(date +%s)
        if (( age < (now - $timeout) )); then
            rm $file
        fi
    fi
    if [ ! -f $file ]; then
        eval "$@ > $file"
    fi
}

refreshaccounts() {
    echo alks developer accounts -e >&2
    alks developer accounts -e | awk '$2~/^[^-]*$/'
}

refreshcreds() {
    local account_list=$TOP/cache/accounts
    cacheget $account_list $((60 * 60 * 24)) refreshaccounts
    source $account_list

    alks_account=${ACCOUNT}_admin
    if [ ! -v $alks_account ]; then
        alks_account=${ACCOUNT}_labadmin
    fi
    if [ ! -v $alks_account ]; then
        alks_account=${ACCOUNT}_security
    fi
    echo $alks_account >&2
    echo alks session open -a -a ${!alks_account} -o aws >&2

    local creds=$(alks sessions open -i -a "${!alks_account}" -o aws)
    echo $creds | gpg --encrypt --armor -r Tommy.Wang@coxautoinc.com
}

credout() {
    if [ -t 1 ]; then
        cat $1 | gpg --decrypt | jq -r
    else
        cat $1 | gpg --decrypt
    fi
}

main() {
    [ -z $ACCOUNT ] && {
        echo error not account selected
        exit 1
    }
    local credfile=$TOP/cache/$ACCOUNT.json.enc
    cacheget $credfile $((60 * 60 * 12)) refreshcreds
    credout $credfile
}

ACCOUNT=${1:-$AWS_PROFILE}
(
    flock -x -w 30 200 || {
        echo "Failed to obtain lock" >&2
        exit 1
    }
    date 2>> $TOP/log 1>&2
    main 2>> $TOP/log
) 200>$LOCK
```

my terraform is at: 
https://ghe.coxautoinc.com/ETS-CloudAutomation/arf-core/tree/internalize/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1
```
$ terragrunt init && terragrunt plan
[terragrunt] 2020/05/15 18:22:52 Reading Terragrunt config file at /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1/terragrunt.hcl
[terragrunt] [/opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1] 2020/05/15 18:22:52 Running command: terraform --version
[terragrunt] 2020/05/15 18:22:52 Downloading Terraform configurations from file:///opt/app/pipelines/sources into /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1/.terragrunt-cache/ajTEf2z8xkSKhk5X7MFNlkpkC4s/vMY7xf-J3iXocfIFbZt_mVdoqQI
[terragrunt] 2020/05/15 18:22:53 Copying files from /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1 into /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1/.terragrunt-cache/ajTEf2z8xkSKhk5X7MFNlkpkC4s/vMY7xf-J3iXocfIFbZt_mVdoqQI/deployment/alks_roles
[terragrunt] 2020/05/15 18:22:53 Setting working directory to /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1/.terragrunt-cache/ajTEf2z8xkSKhk5X7MFNlkpkC4s/vMY7xf-J3iXocfIFbZt_mVdoqQI/deployment/alks_roles
[terragrunt] 2020/05/15 18:22:53 Generated file /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1/.terragrunt-cache/ajTEf2z8xkSKhk5X7MFNlkpkC4s/vMY7xf-J3iXocfIFbZt_mVdoqQI/deployment/alks_roles/provider.tf.
[terragrunt] 2020/05/15 18:22:53 Generated file /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1/.terragrunt-cache/ajTEf2z8xkSKhk5X7MFNlkpkC4s/vMY7xf-J3iXocfIFbZt_mVdoqQI/deployment/alks_roles/backend.tf.
[terragrunt] 2020/05/15 18:22:53 Initializing remote state for the s3 backend
[terragrunt] 2020/05/15 18:22:54 Running command: terraform init
Initializing modules...
- arf_keys in ../../modules/import_arf_keys
- artifacts in ../../modules/import_artifacts
- deploy_build_base_policy in ../modules/codebuild_policies
- meta_build_base_policy in ../modules/codebuild_policies

Initializing the backend...

Successfully configured the backend "s3"! Terraform will automatically
use this backend unless the backend configuration changes.

Initializing provider plugins...
- Checking for available provider plugins...
- Downloading plugin for provider "aws" (hashicorp/aws) 2.62.0...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
[terragrunt] 2020/05/15 18:23:05 Reading Terragrunt config file at /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1/terragrunt.hcl
[terragrunt] [/opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1] 2020/05/15 18:23:05 Running command: terraform --version
[terragrunt] 2020/05/15 18:23:05 Downloading Terraform configurations from file:///opt/app/pipelines/sources into /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1/.terragrunt-cache/ajTEf2z8xkSKhk5X7MFNlkpkC4s/vMY7xf-J3iXocfIFbZt_mVdoqQI
[terragrunt] 2020/05/15 18:23:06 Copying files from /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1 into /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1/.terragrunt-cache/ajTEf2z8xkSKhk5X7MFNlkpkC4s/vMY7xf-J3iXocfIFbZt_mVdoqQI/deployment/alks_roles
[terragrunt] 2020/05/15 18:23:06 Setting working directory to /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1/.terragrunt-cache/ajTEf2z8xkSKhk5X7MFNlkpkC4s/vMY7xf-J3iXocfIFbZt_mVdoqQI/deployment/alks_roles
[terragrunt] 2020/05/15 18:23:06 The file path /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1/.terragrunt-cache/ajTEf2z8xkSKhk5X7MFNlkpkC4s/vMY7xf-J3iXocfIFbZt_mVdoqQI/deployment/alks_roles/provider.tf already exists and if_exists for code generation set to "overwrite". Regenerating file.
[terragrunt] 2020/05/15 18:23:06 Generated file /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1/.terragrunt-cache/ajTEf2z8xkSKhk5X7MFNlkpkC4s/vMY7xf-J3iXocfIFbZt_mVdoqQI/deployment/alks_roles/provider.tf.
[terragrunt] 2020/05/15 18:23:06 The file path /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1/.terragrunt-cache/ajTEf2z8xkSKhk5X7MFNlkpkC4s/vMY7xf-J3iXocfIFbZt_mVdoqQI/deployment/alks_roles/backend.tf already exists, but was a previously generated file by terragrunt. Since if_exists for code generation is set to "overwrite_terragrunt", regenerating file.
[terragrunt] 2020/05/15 18:23:06 Generated file /opt/app/pipelines/dev/deployment/alks_roles/awsmarvendeploynp/us-east-1/.terragrunt-cache/ajTEf2z8xkSKhk5X7MFNlkpkC4s/vMY7xf-J3iXocfIFbZt_mVdoqQI/deployment/alks_roles/backend.tf.
[terragrunt] 2020/05/15 18:23:07 Running command: terraform plan
2020/05/15 18:23:07 [WARN] Log levels other than TRACE are currently unreliable, and are supported only for backward compatibility.
  Use TF_LOG=TRACE to see Terraform's internal logs.
  ----
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

alks_iamrole.deploy_pipeline_role: Refreshing state... [id=arfdev-deploy_pipeline-role]
alks_iamrole.deploy_build_role: Refreshing state... [id=arfdev-deploy_build-role]
alks_iamrole.meta_build_role: Refreshing state... [id=arfdev-meta_build-role]
module.artifacts.data.aws_ssm_parameter.regions: Refreshing state...
module.arf_keys.data.aws_kms_key.arf_keys["ssm"]: Refreshing state...
data.aws_region.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_organizations_organization.org: Refreshing state...
module.artifacts.data.aws_ssm_parameter.artifacts["us-west-2"]: Refreshing state...
module.artifacts.data.aws_ssm_parameter.artifacts["us-east-2"]: Refreshing state...
module.artifacts.data.aws_ssm_parameter.artifacts["us-east-1"]: Refreshing state...
module.artifacts.data.aws_ssm_parameter.artifacts["us-west-1"]: Refreshing state...
data.aws_iam_policy_document.deploy_pipeline_policy_document: Refreshing state...
data.aws_iam_policy_document.deploy_build_policy_document: Refreshing state...
module.meta_build_base_policy.data.aws_iam_policy_document.policy: Refreshing state...
module.deploy_build_base_policy.data.aws_iam_policy_document.policy: Refreshing state...
aws_iam_role_policy.deploy_pipeline_policy: Refreshing state... [id=arfdev-deploy_pipeline-role:arfdev-deploy_pipeline-policy]
aws_ssm_parameter.deploy_pipeline_role_param: Refreshing state... [id=/arfdev/pipelines/deploy/pipeline_role]
module.meta_build_base_policy.aws_iam_role_policy.attach_policy: Refreshing state... [id=arfdev-meta_build-role:arfdev-meta_build-base-policy]
aws_ssm_parameter.meta_build_role_param: Refreshing state... [id=/arfdev/pipelines/meta/build_role]
aws_iam_role_policy.deploy_build_policy: Refreshing state... [id=arfdev-deploy_build-role:arfdev-deploy_build-policy]
module.deploy_build_base_policy.aws_iam_role_policy.attach_policy: Refreshing state... [id=arfdev-deploy_build-role:arfdev-deploy_build-base-policy]
aws_ssm_parameter.deploy_build_role_param: Refreshing state... [id=/arfdev/pipelines/deploy/build_role]
data.aws_iam_policy_document.meta_build_policy_document: Refreshing state...
aws_iam_role_policy.meta_build_policy: Refreshing state... [id=arfdev-meta_build-role:arfdev-meta_build-policy]

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```