### PR TITLE
Validate ARN - Allow MIs

### DIFF
--- a/config.go
+++ b/config.go
@@ -182,7 +182,7 @@ func isValidIAM(arn *string) bool {
 			- IAMAdmin
 			-Machine Identities.
 	*/
-	if strings.Contains(*arn, "assumed-role/Admin/") || strings.Contains(*arn, "assumed-role/IAMAdmin/") || (strings.Contains(*arn, "arn:aws:sts::") && strings.Contains(*arn, "assumed-role/")) {
+	if strings.Contains(*arn, "assumed-role/Admin/") || strings.Contains(*arn, "assumed-role/IAMAdmin/") || strings.Contains(*arn, "arn:aws:sts::") {
 		return true
 	}
 

--- a/config.go
+++ b/config.go
@@ -174,9 +174,15 @@ func getPluginVersion() string {
 	return "unknown"
 }
 
-func isValidIAM(cident *string) bool {
+func isValidIAM(arn *string) bool {
 
-	if strings.Contains(*cident, "assumed-role/Admin/") || strings.Contains(*cident, "assumed-role/IAMAdmin/") {
+	/*
+		Validates ARN for assumed-role of:
+			- Admin
+			- IAMAdmin
+			-Machine Identities.
+	*/
+	if strings.Contains(*arn, "assumed-role/Admin/") || strings.Contains(*arn, "assumed-role/IAMAdmin/") || (strings.Contains(*arn, "arn:aws:sts::") && strings.Contains(*arn, "assumed-role/")) {
 		return true
 	}
 

--- a/config.go
+++ b/config.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 
-	alks "github.com/Cox-Automotive/alks-go"
+	"github.com/Cox-Automotive/alks-go"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
@@ -187,9 +187,16 @@ func isValidIAM(arn *string, client *alks.Client) bool {
 	}
 
 	// Check if MI...
-	_, err := client.SearchRoleMachineIdentity(*arn)
+	arnParts := strings.FieldsFunc(*arn, splitBy)
+	iamArn := fmt.Sprintf("arn:aws:iam::%s:role/acct-managed/%s", arnParts[3], arnParts[5])
+
+	_, err := client.SearchRoleMachineIdentity(iamArn)
 	if err != nil {
 		return false
 	}
 	return true
+}
+
+func splitBy(r rune) bool {
+	return r == ':' || r == '/'
 }

--- a/config.go
+++ b/config.go
@@ -146,14 +146,14 @@ providing credentials for the ALKS Provider`)
 		return nil, serr
 	}
 
+	// got good creds, create alks sts client
+	client, err := alks.NewSTSClient(c.URL, cp.AccessKeyID, cp.SecretAccessKey, cp.SessionToken)
+
 	// check if the user is using a assume-role IAM admin session
-	if isValidIAM(cident.Arn) != true {
+	if isValidIAM(cident.Arn, client) != true {
 		return nil, errors.New("Looks like you are not using ALKS IAM credentials. This will result in errors when creating roles. \n " +
 			"Note: If using ALKS CLI to get credentials, be sure to use the '-i' flag. \n Please see https://coxautoinc.sharepoint.com/sites/service-internal-tools-team/SitePages/ALKS-Terraform-Provider---Troubleshooting.aspx for more information.")
 	}
-
-	// got good creds, create alks sts client
-	client, err := alks.NewSTSClient(c.URL, cp.AccessKeyID, cp.SecretAccessKey, cp.SessionToken)
 
 	if err != nil {
 		return nil, err
@@ -174,15 +174,22 @@ func getPluginVersion() string {
 	return "unknown"
 }
 
-func isValidIAM(arn *string) bool {
+func isValidIAM(arn *string, client *alks.Client) bool {
 
 	/*
 		Validates ARN for assumed-role of:
 			- Admin
 			- IAMAdmin
-			-Machine Identities.
+			- Machine Identities.
 	*/
-	if strings.Contains(*arn, "assumed-role/Admin/") || strings.Contains(*arn, "assumed-role/IAMAdmin/") || strings.Contains(*arn, "arn:aws:sts::") {
+	if strings.Contains(*arn, "assumed-role/Admin/") || strings.Contains(*arn, "assumed-role/IAMAdmin/") {
+		return true
+	} else if strings.Contains(*arn, "arn:aws:sts::") {
+		// Check if MI...
+		_, err := client.SearchRoleMachineIdentity(*arn)
+		if err != nil {
+			return false
+		}
 		return true
 	}
 


### PR DESCRIPTION
This PR adds validation logic to allow MIs ARN. Previously we only allowed assumed-role ARNs, but didn't allow MIs. 