### PR TITLE
Validate ARN - Allow LabAdmins

### DIFF
--- a/config.go
+++ b/config.go
@@ -182,7 +182,7 @@ func getPluginVersion() string {
 */
 func isValidIAM(arn *string, client *alks.Client) bool {
 	// Check if Admin || IAMAdmin
-	if strings.Contains(*arn, "assumed-role/Admin/") || strings.Contains(*arn, "assumed-role/IAMAdmin/") {
+	if strings.Contains(*arn, "assumed-role/Admin/") || strings.Contains(*arn, "assumed-role/IAMAdmin/") || strings.Contains(*arn, "assumed-role/LabAdmin/") {
 		return true
 	}
 


### PR DESCRIPTION
This PR adds validation logic to allow LabAdmin ALKS role-based ARNs. 