### PR TITLE
Multi Account Provider Capability!

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,25 @@ resource "alks_ltk" "test_ltk_user" {
 | `access_key`   | Computed | n/a        | string     | Generated access key for the LTK user. Note: This is saved in the state file, so please be aware of this.                                                                                                                                                         |
 | `secret_key`   | Computed | n/a        | string     | Generated secret key for the LTK user. Note: This is saved in the state file, so please be aware of this.                                                                                                                                                         |
 
+### Data Source Configuration
+#### `alks_keys`
+```tf
+data "alks_keys" "account_keys" {
+   providers: alks.my_alias
+}
+```
+
+| Value          | Type     | Forces New | Value Type | Description                                                                                                                                                                                                                                                       |
+| -------------- | -------- | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `access_key`   | Computed | n/a        | string     | Generated access key for the specified provider. If multiple providers, it takes the `provider` field. Otherwise uses the initial provider.                                                                                                                                                        |
+| `secret_key`   | Computed | n/a        | string     | Generated secret key for the specified provider. If multiple providers, it takes the `provider` field. Otherwise uses the initial provider.                                                                                                                                                   |
+| `session_token`| Computed | n/a        | string     | Generated session token for the specified provider. If multiple providers, it takes the `provider` field. Otherwise uses the initial provider.                                                                                                                                 |
+| `account`   | Computed    | n/a        | string     | The account number of the returned keys.  
+| `role`   | Computed       | n/a        | string     | The role from the returned keys.   
+
+_Note: This does not take any arguments. See below._ 
+- **How it works**: Whatever your default provider credentials are, will be used. If multiple providers have been configured, then one can point the data source to return keys for specific providers using `providers` field with a specific `alias`.
+
 
 ## Example
 

--- a/config.go
+++ b/config.go
@@ -125,7 +125,7 @@ func getCredentialsFromSession(c *Config) (*credentials.Credentials, error) {
 
 // Client returns a properly configured ALKS client or an appropriate error if initialization fails
 func (c *Config) Client() (*alks.Client, error) {
-	log.Println("[DEBUG] Validating STS credentials") // TODO: Fix typo.
+	log.Println("[DEBUG] Validating STS credentials")
 
 	// lookup credentials
 	creds := getCredentials(c)

--- a/config.go
+++ b/config.go
@@ -177,7 +177,7 @@ func (c *Config) Client() (*alks.Client, error) {
 	// 1. Check if calling for a specific account
 	if len(c.Account) > 0 && len(c.Role) > 0 {
 		// 2. Generate client specified
-		client, err = generateNewClient(c, cident, client)
+		client, err = generateNewClient(c, client)
 		if err != nil {
 			return nil, err
 		}
@@ -232,7 +232,7 @@ func splitBy(r rune) bool {
 	return r == ':' || r == '/'
 }
 
-func generateNewClient(c *Config, cident *sts.GetCallerIdentityOutput, client *alks.Client) (*alks.Client, error) {
+func generateNewClient(c *Config, client *alks.Client) (*alks.Client, error) {
 
 	// 3. Create account string
 	newAccDetail := c.Account + "/ALKS" + c.Role

--- a/config.go
+++ b/config.go
@@ -288,7 +288,12 @@ func generateNewClient(c *Config, cident *sts.GetCallerIdentityOutput, client *a
 		client.AccountDetails.Account = newAccDetail
 		client.AccountDetails.Role = c.Role
 
-		newCreds, _ := client.CreateIamSession()
+		newCreds, err := client.CreateIamSession()
+
+		if err != nil {
+			return nil, err
+		}
+
 		newClient, err := alks.NewSTSClient(c.URL, newCreds.AccessKey, newCreds.SecretKey, newCreds.SessionToken)
 
 		if err != nil {

--- a/data_source_alks_keys.go
+++ b/data_source_alks_keys.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"github.com/Cox-Automotive/alks-go"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"strings"
+)
+
+func dataSourceAlksAccountCreds() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlksAccountCredsRead,
+		Schema: map[string]*schema.Schema{
+			"access_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"secret_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"session_token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"account": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAlksAccountCredsRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] ALKS Account Credential Read")
+
+	client := meta.(*alks.Client)
+	resp, err := client.CreateIamSession()
+
+	if err != nil {
+		return err
+	}
+
+	// Return the information to user.
+	_ = d.Set("access_key", resp.AccessKey)
+	_ = d.Set("secret_key", resp.SecretKey)
+	_ = d.Set("session_token", resp.SessionToken)
+	_ = d.Set("account", client.AccountDetails.Account)
+	_ = d.Set("role", strings.Split(client.AccountDetails.Role, "/")[0])
+
+	return nil
+}

--- a/data_source_alks_keys.go
+++ b/data_source_alks_keys.go
@@ -52,5 +52,7 @@ func dataSourceAlksKeysRead(d *schema.ResourceData, meta interface{}) error {
 	_ = d.Set("account", client.AccountDetails.Account)
 	_ = d.Set("role", strings.Split(client.AccountDetails.Role, "/")[0])
 
+	d.SetId(client.AccountDetails.Account)
+
 	return nil
 }

--- a/data_source_alks_keys.go
+++ b/data_source_alks_keys.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 )
 
-func dataSourceAlksAccountCreds() *schema.Resource {
+func dataSourceAlksKeys() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlksAccountCredsRead,
+		Read: dataSourceAlksKeysRead,
 		Schema: map[string]*schema.Schema{
 			"access_key": {
 				Type:     schema.TypeString,
@@ -35,8 +35,8 @@ func dataSourceAlksAccountCreds() *schema.Resource {
 	}
 }
 
-func dataSourceAlksAccountCredsRead(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[INFO] ALKS Account Credential Read")
+func dataSourceAlksKeysRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] ALKS Keys Data Source Read")
 
 	client := meta.(*alks.Client)
 	resp, err := client.CreateIamSession()

--- a/examples/alks.tf
+++ b/examples/alks.tf
@@ -2,18 +2,36 @@
 # PROVIDERS
 #
 provider "alks" {
-    url      = "https://alks.foo.com/rest"
+  url = "https://alks.foo.com/rest"
 }
+
+provider "alks" {
+  url     = "https://alks.foo.com/rest"
+  account = "<account No>"
+  role    = "<role>"
+  alias   = "second"
+}
+
 
 provider "aws" {
-    region     = "us-east-1"
+  region = "us-east-1"
 }
 
-# CREATE IAM ROLE
+# CREATE IAM ROLE -- Initial Provider
 resource "alks_iamrole" "test_role" {
-    name                     = "aba-test-123456"
-    type                     = "Amazon EC2"
-    include_default_policies = false
+  name                     = "TEST-DELETE"
+  type                     = "AWS CodeBuild"
+  include_default_policies = false
+  enable_alks_access       = true
+}
+
+# CREATE IAM ROLE -- Secondary Provider
+resource "alks_iamrole" "test_role_nonprod" {
+  provider                 = alks.second
+  name                     = "TEST-DELETE"
+  type                     = "AWS CodeBuild"
+  include_default_policies = false
+  enable_alks_access       = true
 }
 
 # ATTACH POLICY

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    alks = {
+      source = "coxautoinc.com/engineering-enablement/alks"
+    }
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     alks = {
-      source = "coxautoinc.com/engineering-enablement/alks"
+      source  = "coxautoinc.com/engineering-enablement/alks"
+      version = "1.4.4"
     }
     aws = {
       source = "hashicorp/aws"

--- a/provider.go
+++ b/provider.go
@@ -80,6 +80,10 @@ func Provider() terraform.ResourceProvider {
 			"alks_ltk":          resourceAlksLtk(),
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"alks_keys": dataSourceAlksKeys(),
+		},
+
 		ConfigureFunc: providerConfigure,
 	}
 }

--- a/provider.go
+++ b/provider.go
@@ -59,6 +59,18 @@ func Provider() terraform.ResourceProvider {
 				Description: "The path to the shared credentials file. If not set this defaults to ~/.aws/credentials.",
 				DefaultFunc: schema.EnvDefaultFunc("AWS_SHARED_CREDENTIALS_FILE", nil),
 			},
+			"account": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The account which you'd like to retrieve credentials for.",
+				DefaultFunc: schema.EnvDefaultFunc("Account", nil),
+			},
+			"role": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The role which you'd like to retrieve credentials for.",
+				DefaultFunc: schema.EnvDefaultFunc("Role", nil),
+			},
 			"assume_role": assumeRoleSchema(),
 		},
 
@@ -111,6 +123,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		SecretKey: d.Get("secret_key").(string),
 		Token:     d.Get("token").(string),
 		Profile:   d.Get("profile").(string),
+		Account:   d.Get("account").(string),
+		Role:      d.Get("role").(string),
 	}
 
 	assumeRoleList := d.Get("assume_role").(*schema.Set).List()


### PR DESCRIPTION
This is an implementation of this feature request: https://github.com/Cox-Automotive/terraform-provider-alks/issues/71. The way this works is quite simple, but basically here's an example of it in the works:

**How to use?**
```
provider "alks" {
  url = "https://alks.coxautoinc.com/rest"
}

provider "alks" {
  url     = "https://alks.coxautoinc.com/rest"
  account = "<account No>"
  role    = "<role>"
  alias   = "second"
}

# CREATE IAM ROLE -- Initial Provider
resource "alks_iamrole" "test_role" {
  name                     = "TEST-DELETE"
  type                     = "AWS CodeBuild"
  include_default_policies = false
  enable_alks_access       = true
}

# CREATE IAM ROLE -- Secondary Provider
resource "alks_iamrole" "test_role_nonprod" {
  provider                 = alks.second
  name                     = "TEST-DELETE"
  type                     = "AWS CodeBuild"
  include_default_policies = false
  enable_alks_access       = true
}
```

As long as you specify another provider with the `account`, `role`, and `alias` attributes, then you're able to generate resources for multiple accounts (THAT YOU HAVE ACCESS TO) in one `terraform apply`. This is pretty powerful stuff, and could be even extended to modules. 

**How was this implemented?**
Here's the flow as it is easier than explaining (look at code :))
1. Get credentials like normal for the initial connection - can think of this as the "main" account access.
2. If the account and role fields are set, then let's generate new STS session for the specified account/role. Note: this will verify if you have access to the account, so no tricks please.
3. Once we validate, and STS keys are generated, set the new session for the provider.
4. Done!