### PR TITLE
Go Releaser Setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+# This GitHub action can publish assets for release when a tag is created.
+# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
+#
+# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your
+# private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
+# secret. If you would rather own your own GPG handling, please fork this action
+# or use an alternative one for key handling.
+#
+# You will need to pass the `--batch` flag to `gpg` in your signing step
+# in `goreleaser` to indicate this is being used in a non-interactive mode.
+#
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      -
+        name: Import GPG key
+        id: import_gpg
+        uses: paultyng/ghaction-import-gpg@v2.1.0
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
       - -trimpath
       - -tags=all
     ldflags:
-      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+      - '-s -w -X main.versionNumber={{.Version}}'
     goos:
       - windows
       - linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,5 +51,3 @@ signs:
 release:
   # Visit your project's GitHub Releases page to publish this release.
   draft: true
-#changelog:
-#  skip: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,55 @@
+# Visit https://goreleaser.com for documentation on how to customize this
+# behavior.
+before:
+  hooks:
+    # this is just an example and not a requirement for provider building/publishing
+    - go mod tidy
+builds:
+  - env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like Terraform Cloud where
+      # they are unable to install libraries.
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+      - -tags=all
+    ldflags:
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    goos:
+      - windows
+      - linux
+      - darwin
+      - freebsd
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
+archives:
+  - format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      # if you are using this is a GitHub action or some other automated pipeline, you
+      # need to pass the batch flag to indicate its not interactive.
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+release:
+  # Visit your project's GitHub Releases page to publish this release.
+  draft: true
+#changelog:
+#  skip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,27 +11,6 @@ install:
 before_deploy:
   - make release
 
-deploy:
-  provider: releases
-  api_key:
-    secure: MZOznxDJeaIT3IQYDZHoH7oazeuM8ekgZzvnUTq0gMHZc1gwB9uEYjvCwSVo0OlUKFPymarhv/65GolggV1+fZzig5HPOpJltTFj3w9RBXZZzZiNZ3X+eexyW+so07BtV1S+jytA/Dd8MpnT9EmCYTzpg6Gp/NosyQJ9FbS7hm8UQcH7PLiBWAeoL1Wb/aLZQZUQRBiYr8PmZ6lzVTY+w8h5KISi7TrL6EzbwXj3j3muCGm/9ZqX/6CAxmAydU0ozCjl4QksRqn2MDWgUSYgga2GKBqsTpU4hX05QCEXD/G2BcGmoaOFP29na+zhXlCZ9j7DrOCMisEWH/DiWwqWaNlqUgO81pGbQDayvpZAMGRrYsaSQTz7oEbuU88NeDFriy44WFGE+eE73ykPFQl6JNnptE3mF6dRVPb6GZhG0nzM+UKfNw4hhcWo45hmrfqLS8MJNci9O3HbMy+2Ka45u64RlX2AUnmNexdPFDmZSjARLrnFT4VUuTEeb3CRS8TmNaWEM1o2yWYgtCkM9qnhiAxlrcDt1Y/bqhgbhzoheslHmi+n9TlFeH1xHP9sTEOwji5ljyPv2iN0/YdInkz+lF/4gEQSZ6hvLGGp+v3FUV66PU8dCusw9ysJhlJ40pvobz7MNdsiscDBx0zqiYUAdSR7XSgUQV7aOJH6dmnqwQA=
-  file:
-    - release/terraform-provider-alks_${TRAVIS_TAG}_darwin_amd64.zip
-    - release/terraform-provider-alks_${TRAVIS_TAG}_freebsd_386.zip
-    - release/terraform-provider-alks_${TRAVIS_TAG}_freebsd_amd64.zip
-    - release/terraform-provider-alks_${TRAVIS_TAG}_linux_386.zip
-    - release/terraform-provider-alks_${TRAVIS_TAG}_linux_amd64.zip
-    - release/terraform-provider-alks_${TRAVIS_TAG}_solaris_amd64.zip
-    - release/terraform-provider-alks_${TRAVIS_TAG}_windows_386.zip
-    - release/terraform-provider-alks_${TRAVIS_TAG}_windows_amd64.zip
-    - release/terraform-provider-alks_${TRAVIS_TAG}_SHA256SUMS
-    - release/terraform-provider-alks_${TRAVIS_TAG}_SHA256SUMS.sig
-  skip_cleanup: true
-  on:
-    repo: Cox-Automotive/terraform-provider-alks
-    tags: true
-    all_branches: false
-
 notifications:
   email: false
   slack:


### PR DESCRIPTION
**Leaving this here...**
![alks-tfp](https://user-images.githubusercontent.com/57536014/97218823-93181500-179f-11eb-8a33-f28a6642e4d1.gif)

Alright, so manually setting up our releases + publishing failed. After discussing with HashiCorp the `goreleaser` is definitely the final option we have in publishing our provider, and it should _just work_. This adds new `.github/workflows/` for our Github actions, and a new `.goreleaser` for releasing all of the necessary assets just like it would in our TravisCI `deploy:` command. This will kick off once a tag is created, so nothing in our process is changed other than how we deploy.

Note: The secrets have been added to our repository settings which include passphrase and the GPG key block.