### PR TITLE
Cleanup go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/Cox-Automotive/alks-go v0.0.0-20200714135032-e03438e39d50
 	github.com/aws/aws-sdk-go v1.31.15
-	github.com/hashicorp/go-cleanhttp v0.5.1
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/terraform v0.12.26
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/motain/gocheck v0.0.0-20131023154940-9beb271d26e6 // indirect


### PR DESCRIPTION
This runs `go mod vendor` for the following reason:
- `github.com/hashicorp/go-cleanhttp@v0.5.1: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod`

Should clean this up, and our PRs should include this command before releasing to sync everything.