### PR TITLE
Fix Releaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,6 @@ before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
-    - go mod vendor
 builds:
   - env:
       # goreleaser does not work with CGO, it could also complicate
@@ -26,6 +25,7 @@ builds:
       - amd64
       - '386'
       - arm
+      - arm64
     ignore:
       - goos: darwin
         goarch: '386'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,6 @@ builds:
       - amd64
       - '386'
       - arm
-      - arm64
     ignore:
       - goos: darwin
         goarch: '386'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,7 @@ before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
+    - go mod vendor
 builds:
   - env:
       # goreleaser does not work with CGO, it could also complicate


### PR DESCRIPTION
I believe what causes issues is using `go mod tidy`, so I added the line: `go mod vendor` to sync. If this does not work I might have to remove the `go mod tidy` altogether. Only can know once we release a new tag because locally this is the only way to test.