### PR TITLE
Cleanup installation docs

### DIFF
--- a/docs/guides/local_installation.md
+++ b/docs/guides/local_installation.md
@@ -2,36 +2,55 @@
 page_title: "Local Installation"
 ---
 
-### Terraform Version < 0.13 Local Installation
+### Terraform Version 0.12 Local Installation
 * Download and install [Terraform](https://www.terraform.io/intro/getting-started/install.html)
 
 * Download ALKS Provider binary for your platform from [Releases](https://github.com/Cox-Automotive/terraform-provider-alks/releases)
 
-For example on macOS:
-
+One-liner download for macOS / Linux:
 ```
-curl https://github.com/Cox-Automotive/terraform-provider-alks/releases/download/1.5.0/terraform-provider-alks_1.5.0_darwin_amd64.zip -O -J -L | unzip
+mkdir -p ~/.terraform.d/plugins &&
+      curl -Ls https://api.github.com/repos/Cox-Automotive/terraform-provider-alks/releases/latest |
+      jq -r ".assets[] | select(.browser_download_url | contains(\"$(uname -s | tr A-Z a-z)\")) | select(.browser_download_url | contains(\"amd64\")) | .browser_download_url" |
+            xargs -n 1 curl -Lo ~/.terraform.d/plugins/terraform-provider-alks.zip &&
+      pushd ~/.terraform.d/plugins/ &&
+      unzip ~/.terraform.d/plugins/terraform-provider-alks.zip -d terraform-provider-alks-tmp &&
+      mv terraform-provider-alks-tmp/terraform-provider-alks* . &&
+      chmod +x terraform-provider-alks* &&
+      rm -rf terraform-provider-alks-tmp &&
+      rm -rf terraform-provider-alks.zip &&
+      popd
 ```
 
 * Configure Terraform to use this plugin by placing the binary in `.terraform.d/plugins/` on MacOS/Linux or `terraform.d\plugins\` in your user's "Application Data" directory on Windows.
 
 * Note: If you've used a previous version of the ALKS provider and created a `.terraformrc` file in your home directory you'll want to remove it prior to updating.
 
-### Terraform Version >= 0.13 Local Installation
+### Terraform Version 0.13 Local Installation
 * Download and install [Terraform](https://www.terraform.io/intro/getting-started/install.html)
 
 * Download ALKS Provider binary for your platform from [Releases](https://github.com/Cox-Automotive/terraform-provider-alks/releases)
   
-For example on macOS:
-
+One-liner download for macOS / Linux:
 ```
-curl https://github.com/Cox-Automotive/terraform-provider-alks/releases/download/1.5.0/terraform-provider-alks_1.5.0_darwin_amd64.zip -O -J -L | unzip
+mkdir -p ~/.terraform.d/plugins &&
+      curl -Ls https://api.github.com/repos/Cox-Automotive/terraform-provider-alks/releases/latest |
+      jq -r ".assets[] | select(.browser_download_url | contains(\"$(uname -s | tr A-Z a-z)\")) | select(.browser_download_url | contains(\"amd64\")) | .browser_download_url" |
+            xargs -n 1 curl -Lo ~/.terraform.d/plugins/terraform-provider-alks.zip &&
+      pushd ~/.terraform.d/plugins/ &&
+      unzip ~/.terraform.d/plugins/terraform-provider-alks.zip -d terraform-provider-alks-tmp &&
+      mv terraform-provider-alks-tmp/terraform-provider-alks* . &&
+      chmod +x terraform-provider-alks* &&
+      rm -rf terraform-provider-alks-tmp &&
+      rm -rf terraform-provider-alks.zip &&
+      popd
 ```
+!> **Warning:** Your binary has been placed in `.terraform.d/plugins/`; this will **NOT** suffice for Terraform version 0.13. For more information, [read here](https://www.terraform.io/upgrade-guides/0-13.html#new-filesystem-layout-for-local-copies-of-providers).
 
 * Go into the Terraform plugins path; `.terraform.d/plugins/` on MacOS/Linux or `terraform.d\plugins\` in your user's "Application Data" directory on Windows.
 
-* Create the following directories: `coxautoinc.com/engineering-enablement/alks/1.5.0/<OS>_<ARCH>` and put the binary into the `<OS>_<ARCH>/` directory.
-  * Note: This `<OS>_<ARCH>` will vary depending on your system. For example, 64-bit MacOS would be: `darwin_amd64` while 64-bit Windows 10 would be: `windows_amd64` 
+* Create the following directories: `coxautoinc.com/engineering-enablement/alks/<VERSION>/<OS>_<ARCH>` and put the binary into the `<OS>_<ARCH>/` directory.
+  * Note: This `<OS>_<ARCH>` will vary depending on your system. For example, 64-bit MacOS will be: `darwin_amd64` while 64-bit Windows 10 will be: `windows_amd64` 
 
 * Finally, configure Terraform.
     * In your `versions.tf` or `main.tf` file you'll want to add the new ALKS provider as such:
@@ -39,9 +58,9 @@ curl https://github.com/Cox-Automotive/terraform-provider-alks/releases/download
     terraform {
         required_version = ">= 0.13"
         required_providers {
-        alks = {
-            source = "coxautoinc.com/engineering-enablement/alks"
-            }
+           alks = {
+              source = "coxautoinc.com/engineering-enablement/alks"
+           }
         }
     }
     ```

--- a/docs/guides/local_installation.md
+++ b/docs/guides/local_installation.md
@@ -5,9 +5,7 @@ page_title: "Local Installation"
 ### Terraform Version 0.12 Local Installation
 * Download and install [Terraform](https://www.terraform.io/intro/getting-started/install.html)
 
-* Download ALKS Provider binary for your platform from [Releases](https://github.com/Cox-Automotive/terraform-provider-alks/releases)
-
-One-liner download for macOS / Linux:
+**One-liner download for macOS / Linux:**
 ```
 mkdir -p ~/.terraform.d/plugins &&
       curl -Ls https://api.github.com/repos/Cox-Automotive/terraform-provider-alks/releases/latest |
@@ -21,36 +19,53 @@ mkdir -p ~/.terraform.d/plugins &&
       rm -rf terraform-provider-alks.zip &&
       popd
 ```
+**Manual Installation:**
+
+* Download ALKS Provider binary for your platform from [Releases](https://github.com/Cox-Automotive/terraform-provider-alks/releases)
 
 * Configure Terraform to use this plugin by placing the binary in `.terraform.d/plugins/` on MacOS/Linux or `terraform.d\plugins\` in your user's "Application Data" directory on Windows.
 
 * Note: If you've used a previous version of the ALKS provider and created a `.terraformrc` file in your home directory you'll want to remove it prior to updating.
 
-### Terraform Version 0.13 Local Installation
+* Finally, configure Terraform.
+    * In your `versions.tf` or `main.tf` file you'll want to add the new ALKS provider as such:
+    ```
+    provider "alks" {
+      url       = "https://alks.coxautoinc.com/rest"
+      version   = "YOUR_VERSION_HERE"
+    }
+    ```
+
+
+### Terraform Version 0.13+ Local Installation
 * Download and install [Terraform](https://www.terraform.io/intro/getting-started/install.html)
 
-* Download ALKS Provider binary for your platform from [Releases](https://github.com/Cox-Automotive/terraform-provider-alks/releases)
-  
-One-liner download for macOS / Linux:
+**One-liner download for macOS / Linux:**
 ```
-mkdir -p ~/.terraform.d/plugins &&
+mkdir -p ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/1.5.11/darwin_amd64 &&
       curl -Ls https://api.github.com/repos/Cox-Automotive/terraform-provider-alks/releases/latest |
       jq -r ".assets[] | select(.browser_download_url | contains(\"$(uname -s | tr A-Z a-z)\")) | select(.browser_download_url | contains(\"amd64\")) | .browser_download_url" |
-            xargs -n 1 curl -Lo ~/.terraform.d/plugins/terraform-provider-alks.zip &&
-      pushd ~/.terraform.d/plugins/ &&
-      unzip ~/.terraform.d/plugins/terraform-provider-alks.zip -d terraform-provider-alks-tmp &&
+            xargs -n 1 curl -Lo ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/1.5.11/darwin_amd64/terraform-provider-alks.zip &&
+      pushd ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/1.5.11/darwin_amd64 &&
+      unzip ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/1.5.11/darwin_amd64/terraform-provider-alks.zip -d terraform-provider-alks-tmp &&
       mv terraform-provider-alks-tmp/terraform-provider-alks* . &&
       chmod +x terraform-provider-alks* &&
       rm -rf terraform-provider-alks-tmp &&
       rm -rf terraform-provider-alks.zip &&
       popd
 ```
-!> **Warning:** Your binary has been placed in `.terraform.d/plugins/`; this will **NOT** suffice for Terraform version 0.13. For more information, [read here](https://www.terraform.io/upgrade-guides/0-13.html#new-filesystem-layout-for-local-copies-of-providers).
+!> **Warning:** Your binary has been placed in `/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/1.5.11/darwin_amd64`. For more information on WHY, [read here](https://www.terraform.io/upgrade-guides/0-13.html#new-filesystem-layout-for-local-copies-of-providers).
+
+**Manual Installation:**
+
+* Download ALKS Provider binary for your platform from [Releases](https://github.com/Cox-Automotive/terraform-provider-alks/releases)
 
 * Go into the Terraform plugins path; `.terraform.d/plugins/` on MacOS/Linux or `terraform.d\plugins\` in your user's "Application Data" directory on Windows.
 
 * Create the following directories: `coxautoinc.com/engineering-enablement/alks/<VERSION>/<OS>_<ARCH>` and put the binary into the `<OS>_<ARCH>/` directory.
-  * Note: This `<OS>_<ARCH>` will vary depending on your system. For example, 64-bit MacOS will be: `darwin_amd64` while 64-bit Windows 10 will be: `windows_amd64` 
+  * Note: This `<OS>_<ARCH>` will vary depending on your system. For example, 64-bit MacOS will be: `darwin_amd64` while 64-bit Windows 10 will be: `windows_amd64`
+  
+* Place / `mv` the downloaded binary into the directory above. 
 
 * Finally, configure Terraform.
     * In your `versions.tf` or `main.tf` file you'll want to add the new ALKS provider as such:
@@ -59,10 +74,18 @@ mkdir -p ~/.terraform.d/plugins &&
         required_version = ">= 0.13"
         required_providers {
            alks = {
-              source = "coxautoinc.com/engineering-enablement/alks"
+              source  = "Cox-Automotive/engineering-enablement/alks"
+              version = "YOUR_VERSION_HERE"
            }
         }
     }
     ```
 
 * Note: If you've previously installed our provider, and it is stored in your remote state: you may need to run the [`replace-provider` command](https://www.terraform.io/docs/commands/state/replace-provider.html).
+
+---
+
+### Supported Versions
+| Terraform 0.10.x       | Terraform 0.12.x  | Terraform 0.13.x | Terraform 0.14.x |
+| ----------------       | ----------------  | ---------------- | ---------------- |
+| ALKS TFP 0.9.0 < 1.3.0 | ALKS TFP 1.3.0+   | ALKS TFP 1.3.0+  | ALKS TFP 1.3.0+  |

--- a/docs/guides/local_installation.md
+++ b/docs/guides/local_installation.md
@@ -65,4 +65,4 @@ mkdir -p ~/.terraform.d/plugins &&
     }
     ```
 
-* Note: If you've previously installed our provider and it is stored in your remote state, you may need to run the [`replace-provider` command](https://www.terraform.io/docs/commands/state/replace-provider.html).
+* Note: If you've previously installed our provider, and it is stored in your remote state: you may need to run the [`replace-provider` command](https://www.terraform.io/docs/commands/state/replace-provider.html).


### PR DESCRIPTION
This PR updates our [local installation](https://registry.terraform.io/providers/Cox-Automotive/alks/latest/docs/guides/local_installation) docs. 

Changes for 0.12 instructions:
- Added a one-liner command. Will grab the latest version, and place it in the `/.terraform.d/plugins` with the appropriate version constraint ON the file name. (previously missing that).
- Added instructions to the 0.12 installation for manually downloading as well as HOW to configure the provider itself.

Changes for 0.13 instructions:
- Added a one-liner command. Will grab the latest version, and place it in the `/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/<<LATEST>>/darwin_amd64` directory. Right now the version is hardcoded, so our WIKI has to be updated to include instructions for updating provider versions for the 0.13+ installation instructions.
- Updated some verbiage to be more clear.
- Updated the directory PATH. No longer using `.../plugins/coxautomotive.inc/engineering-enablement/...` as too many people complained that this was far too different than what our registry path is: `"Cox-Automotive/alks"` Note: This only changes the local installation path, not the registry one.

Added a new version matrix / table?
- Basically this tells users which version of Terraform supports which version of ALKS TFP. It's really more used for ancient versions, but anything after `1.3.0` will be supported by all newer versions of TF. 