### PR TITLE
[DEFECT] Replace IsIamEnabled call!

### DIFF
--- a/config.go
+++ b/config.go
@@ -184,8 +184,12 @@ func (c *Config) Client() (*alks.Client, error) {
 	}
 
 	// Validate STS for IAM active.
-	validateSTS, err := client.IsIamEnabled("")
-	if err != nil || validateSTS.IamEnabled != true {
+	validate, err := client.GetMyLoginRole()
+	if err != nil {
+		return nil, err
+	}
+
+	if validate.LoginRole.IamKeyActive != true {
 		return nil, errors.New("Looks like you are not using ALKS IAM credentials. This will result in errors when creating roles. \n " +
 			"Note: If using ALKS CLI to get credentials, be sure to use the '-i' flag. \n Please see https://coxautoinc.sharepoint.com/sites/service-internal-tools-team/SitePages/ALKS-Terraform-Provider---Troubleshooting.aspx for more information.")
 	}


### PR DESCRIPTION
- This replaces `rest/isIamEnabled` with `GetMyLoginRole()` call instead. Tested and verified using a LOCAL install of TFP with an EC2 MI role.