### PR TITLE
Refactor Deprecated Functions

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -18,7 +18,7 @@ func Provider() *schema.Provider {
 				Required:    true,
 				Description: "This is the base URL to ALKS service. It must be provided, but it can also be sourced from the ALKS_URL environment variable.",
 				DefaultFunc: schema.EnvDefaultFunc("ALKS_URL", nil),
-						},
+			},
 			"access_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -26,8 +26,8 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"ALKS_ACCESS_KEY_ID",
 					"AWS_ACCESS_KEY_ID",
-							}, nil),
-						},
+				}, nil),
+			},
 			"secret_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -35,8 +35,8 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"ALKS_SECRET_ACCESS_KEY",
 					"AWS_SECRET_ACCESS_KEY",
-							}, nil),
-						},
+				}, nil),
+			},
 			"token": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -44,8 +44,8 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"ALKS_SESSION_TOKEN",
 					"AWS_SESSION_TOKEN",
-							}, nil),
-						},
+				}, nil),
+			},
 			"profile": {
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/resource_alks_iamrole.go
+++ b/resource_alks_iamrole.go
@@ -144,8 +144,6 @@ func resourceAlksIamRoleCreate(ctx context.Context, d *schema.ResourceData, meta
 func resourceAlksIamTrustRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[INFO] ALKS IAM Trust Role Create")
 
-	var diags diag.Diagnostics
-
 	var roleName = d.Get("name").(string)
 	var roleType = d.Get("type").(string)
 	var trustArn = d.Get("trust_arn").(string)

--- a/resource_alks_iamrole.go
+++ b/resource_alks_iamrole.go
@@ -20,7 +20,7 @@ func resourceAlksIamRole() *schema.Resource {
 		Exists: resourceAlksIamRoleExists,
 		Delete: resourceAlksIamRoleDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		SchemaVersion: 1,

--- a/resource_alks_iamrole.go
+++ b/resource_alks_iamrole.go
@@ -27,44 +27,44 @@ func resourceAlksIamRole() *schema.Resource {
 		MigrateState:  migrateState,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-			},
-			"type": &schema.Schema{
+						},
+			"type": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-			},
-			"include_default_policies": &schema.Schema{
+						},
+			"include_default_policies": {
 				Type:     schema.TypeBool,
 				Required: true,
 				ForceNew: true,
-			},
-			"role_added_to_ip": &schema.Schema{
+						},
+			"role_added_to_ip": {
 				Type:     schema.TypeBool,
 				Computed: true,
-			},
-			"arn": &schema.Schema{
+						},
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-			"ip_arn": &schema.Schema{
+						},
+			"ip_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-			"enable_alks_access": &schema.Schema{
+						},
+			"enable_alks_access": {
 				Type:     schema.TypeBool,
 				Default:  false,
 				Optional: true,
-			},
-			"template_fields": &schema.Schema{
+						},
+			"template_fields": {
 				Type:     schema.TypeMap,
 				Elem:     schema.TypeString,
 				ForceNew: true,
 				Optional: true,
-			},
+						},
 		},
 	}
 }
@@ -84,38 +84,38 @@ func resourceAlksIamTrustRole() *schema.Resource {
 		MigrateState:  migrateState,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-			},
-			"type": &schema.Schema{
+						},
+			"type": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-			},
-			"trust_arn": &schema.Schema{
+						},
+			"trust_arn": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-			},
-			"role_added_to_ip": &schema.Schema{
+						},
+			"role_added_to_ip": {
 				Type:     schema.TypeBool,
 				Computed: true,
-			},
-			"arn": &schema.Schema{
+						},
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-			"ip_arn": &schema.Schema{
+						},
+			"ip_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-			"enable_alks_access": &schema.Schema{
+						},
+			"enable_alks_access": {
 				Type:     schema.TypeBool,
 				Default:  false,
 				Optional: true,
-			},
+						},
 		},
 	}
 }

--- a/resource_alks_iamrole.go
+++ b/resource_alks_iamrole.go
@@ -184,7 +184,7 @@ func resourceAlksIamTrustRoleCreate(ctx context.Context, d *schema.ResourceData,
 
 	log.Printf("[INFO] alks_iamtrustrole.id: %v", d.Id())
 
-	return diags
+	return resourceAlksIamRoleRead(ctx, d, meta)
 }
 
 func resourceAlksIamRoleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/resource_alks_iamrole.go
+++ b/resource_alks_iamrole.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	alks "github.com/Cox-Automotive/alks-go"
+	"github.com/Cox-Automotive/alks-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/resource_alks_iamrole_test.go
+++ b/resource_alks_iamrole_test.go
@@ -29,8 +29,8 @@ func TestAccAlksIamRole_Basic(t *testing.T) {
 						"alks_iamrole.foo", "type", "Amazon EC2"),
 					resource.TestCheckResourceAttr(
 						"alks_iamrole.foo", "include_default_policies", "false"),
-							),
-						},
+				),
+			},
 			{
 				// update the resource
 				Config: testAccCheckAlksIamRoleConfigUpdateBasic,
@@ -43,41 +43,8 @@ func TestAccAlksIamRole_Basic(t *testing.T) {
 						"alks_iamrole.foo", "include_default_policies", "false"),
 					resource.TestCheckResourceAttr(
 						"alks_iamrole.foo", "enable_alks_access", "true"),
-							),
-						},
-		},
-	})
-}
-
-func TestAccAlksIamTrustRole_Basic(t *testing.T) {
-	var resp alks.IamRoleResponse
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAlksIamRoleDestroy(&resp),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAlksIamTrustRoleConfigBasic,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"alks_iamtrustrole.bar", "name", "bar"),
-					resource.TestCheckResourceAttr(
-						"alks_iamtrustrole.bar", "type", "Inner Account"),
-							),
-						},
-			{
-				// update the resource
-				Config: testAccCheckAlksIamTrustRoleConfigUpdateBasic,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"alks_iamtrustrole.bar", "name", "bar"),
-					resource.TestCheckResourceAttr(
-						"alks_iamtrustrole.bar", "type", "Inner Account"),
-					resource.TestCheckResourceAttr(
-						"alks_iamtrustrole.bar", "enable_alks_access", "true"),
-							),
-						},
+				),
+			},
 		},
 	})
 }
@@ -95,34 +62,6 @@ func testAccCheckAlksIamRoleDestroy(role *alks.IamRoleResponse) resource.TestChe
 			if respz != nil {
 				return fmt.Errorf("Role still exists: %#v (%v)", respz, err)
 			}
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckAlksIamRoleExists(n string, role *alks.IamRoleResponse) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No role ID is set")
-		}
-
-		client := testAccProvider.Meta().(*alks.Client)
-
-		foundRole, err := client.GetIamRole(rs.Primary.ID)
-
-		if err != nil {
-			return err
-		}
-
-		if foundRole.RoleArn != rs.Primary.ID {
-			return fmt.Errorf("Role not found")
 		}
 
 		return nil

--- a/resource_alks_iamrole_test.go
+++ b/resource_alks_iamrole_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"testing"
 
-	alks "github.com/Cox-Automotive/alks-go"
+	"github.com/Cox-Automotive/alks-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/resource_alks_iamrole_test.go
+++ b/resource_alks_iamrole_test.go
@@ -18,7 +18,7 @@ func TestAccAlksIamRole_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAlksIamRoleDestroy(&resp),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckAlksIamRoleConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					// testAccCheckAlksIamRoleExists("bar420", &resp),
@@ -29,9 +29,9 @@ func TestAccAlksIamRole_Basic(t *testing.T) {
 						"alks_iamrole.foo", "type", "Amazon EC2"),
 					resource.TestCheckResourceAttr(
 						"alks_iamrole.foo", "include_default_policies", "false"),
-				),
-			},
-			resource.TestStep{
+							),
+						},
+			{
 				// update the resource
 				Config: testAccCheckAlksIamRoleConfigUpdateBasic,
 				Check: resource.ComposeTestCheckFunc(
@@ -43,8 +43,8 @@ func TestAccAlksIamRole_Basic(t *testing.T) {
 						"alks_iamrole.foo", "include_default_policies", "false"),
 					resource.TestCheckResourceAttr(
 						"alks_iamrole.foo", "enable_alks_access", "true"),
-				),
-			},
+							),
+						},
 		},
 	})
 }
@@ -57,16 +57,16 @@ func TestAccAlksIamTrustRole_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAlksIamRoleDestroy(&resp),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckAlksIamTrustRoleConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"alks_iamtrustrole.bar", "name", "bar"),
 					resource.TestCheckResourceAttr(
 						"alks_iamtrustrole.bar", "type", "Inner Account"),
-				),
-			},
-			resource.TestStep{
+							),
+						},
+			{
 				// update the resource
 				Config: testAccCheckAlksIamTrustRoleConfigUpdateBasic,
 				Check: resource.ComposeTestCheckFunc(
@@ -76,8 +76,8 @@ func TestAccAlksIamTrustRole_Basic(t *testing.T) {
 						"alks_iamtrustrole.bar", "type", "Inner Account"),
 					resource.TestCheckResourceAttr(
 						"alks_iamtrustrole.bar", "enable_alks_access", "true"),
-				),
-			},
+							),
+						},
 		},
 	})
 }

--- a/resource_alks_ltk.go
+++ b/resource_alks_ltk.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 
 	"github.com/Cox-Automotive/alks-go"
@@ -9,15 +11,12 @@ import (
 
 func resourceAlksLtk() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceAlksLtkCreate,
-		Read:   resourceAlksLtkRead,
-		Delete: resourceAlksLtkDelete,
-		Exists: resourceAlksLtkExists,
+		CreateContext: resourceAlksLtkCreate,
+		ReadContext:   resourceAlksLtkRead,
+		DeleteContext: resourceAlksLtkDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-
-		SchemaVersion: 1,
 
 		Schema: map[string]*schema.Schema{
 			"iam_username": {
@@ -43,19 +42,19 @@ func resourceAlksLtk() *schema.Resource {
 	}
 }
 
-func resourceAlksLtkCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAlksLtkCreate(ctx context.Context,d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[INFO] ALKS LTK User Create")
 
 	var iamUsername = d.Get("iam_username").(string)
 
 	client := meta.(*alks.Client)
 	if err := validateIAMEnabled(client); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	resp, err := client.CreateLongTermKey(iamUsername)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(iamUsername)
@@ -65,13 +64,19 @@ func resourceAlksLtkCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[INFO] alks_ltk.id: %v", d.Id())
 
-	return resourceAlksLtkRead(d, meta)
+	return resourceAlksLtkRead(ctx, d, meta)
 }
 
-func resourceAlksLtkRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAlksLtkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[INFO] ALKS LTK User Read")
 
 	client := meta.(*alks.Client)
+
+	// Check if role exists.
+	if d.Id() == "" || d.Id() == "none" {
+		return nil
+	}
+
 	resp, err := client.GetLongTermKey(d.Id())
 
 	if err != nil {
@@ -87,35 +92,17 @@ func resourceAlksLtkRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceAlksLtkDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAlksLtkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[INFO] ALKS LTK User Delete")
 
 	client := meta.(*alks.Client)
 	if err := validateIAMEnabled(client); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if _, err := client.DeleteLongTermKey(d.Id()); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	return nil
-}
-
-func resourceAlksLtkExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	log.Printf("[INFO] ALKS LTK User Exists")
-
-	client := meta.(*alks.Client)
-	resp, err := client.GetLongTermKey(d.Id())
-
-	if err != nil {
-		return false, err
-	}
-
-	// We can get a 200, but an empty string so this is the condition to check for.
-	if len(resp.LongTermKey.UserName) == 0 {
-		return false, nil
-	}
-
-	return true, nil
 }

--- a/resource_alks_ltk.go
+++ b/resource_alks_ltk.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	alks "github.com/Cox-Automotive/alks-go"
+	"github.com/Cox-Automotive/alks-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/resource_alks_ltk.go
+++ b/resource_alks_ltk.go
@@ -24,7 +24,7 @@ func resourceAlksLtk() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-						},
+									},
 			"iam_user_arn": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/resource_alks_ltk.go
+++ b/resource_alks_ltk.go
@@ -14,8 +14,7 @@ func resourceAlksLtk() *schema.Resource {
 		Delete: resourceAlksLtkDelete,
 		Exists: resourceAlksLtkExists,
 		Importer: &schema.ResourceImporter{
-			// Terraform provided importer
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		SchemaVersion: 1,

--- a/resource_alks_ltk.go
+++ b/resource_alks_ltk.go
@@ -20,25 +20,25 @@ func resourceAlksLtk() *schema.Resource {
 		SchemaVersion: 1,
 
 		Schema: map[string]*schema.Schema{
-			"iam_username": &schema.Schema{
+			"iam_username": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-			},
-			"iam_user_arn": &schema.Schema{
+						},
+			"iam_user_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-			"access_key": &schema.Schema{
+						},
+			"access_key": {
 				Sensitive: true,
 				Type:      schema.TypeString,
 				Computed:  true,
-			},
-			"secret_key": &schema.Schema{
+						},
+			"secret_key": {
 				Sensitive: true,
 				Type:      schema.TypeString,
 				Computed:  true,
-			},
+						},
 		},
 	}
 }

--- a/resource_alks_ltk.go
+++ b/resource_alks_ltk.go
@@ -23,26 +23,26 @@ func resourceAlksLtk() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-									},
+			},
 			"iam_user_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
-						},
+			},
 			"access_key": {
 				Sensitive: true,
 				Type:      schema.TypeString,
 				Computed:  true,
-						},
+			},
 			"secret_key": {
 				Sensitive: true,
 				Type:      schema.TypeString,
 				Computed:  true,
-						},
+			},
 		},
 	}
 }
 
-func resourceAlksLtkCreate(ctx context.Context,d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAlksLtkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[INFO] ALKS LTK User Create")
 
 	var iamUsername = d.Get("iam_username").(string)

--- a/resource_alks_ltk_test.go
+++ b/resource_alks_ltk_test.go
@@ -17,15 +17,15 @@ func TestAlksLTKCreate(t *testing.T) {
 		CheckDestroy: testAlksLtkDestroy(&resp),
 		Steps: []resource.TestStep{
 			// Create the resource
-			resource.TestStep{
+			{
 				Config: testAlksLTKCreateConfig,
 				Check:  resource.ComposeTestCheckFunc(resource.TestCheckResourceAttr("alks_ltk.foo", "iam_username", "TEST_LTK_USER")),
-			},
+						},
 			// Update the resource
-			resource.TestStep{
+			{
 				Config: testAlksLTKUpdateConfig,
 				Check:  resource.ComposeTestCheckFunc(resource.TestCheckResourceAttr("alks_ltk.foo", "iam_username", "TEST_LTK_USER_2")),
-			},
+						},
 		},
 	})
 }

--- a/resource_alks_ltk_test.go
+++ b/resource_alks_ltk_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	alks "github.com/Cox-Automotive/alks-go"
+	"github.com/Cox-Automotive/alks-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"testing"

--- a/resource_alks_ltk_test.go
+++ b/resource_alks_ltk_test.go
@@ -20,12 +20,12 @@ func TestAlksLTKCreate(t *testing.T) {
 			{
 				Config: testAlksLTKCreateConfig,
 				Check:  resource.ComposeTestCheckFunc(resource.TestCheckResourceAttr("alks_ltk.foo", "iam_username", "TEST_LTK_USER")),
-						},
+			},
 			// Update the resource
 			{
 				Config: testAlksLTKUpdateConfig,
 				Check:  resource.ComposeTestCheckFunc(resource.TestCheckResourceAttr("alks_ltk.foo", "iam_username", "TEST_LTK_USER_2")),
-						},
+			},
 		},
 	})
 }


### PR DESCRIPTION
This PR builds on the previous PR. Now that we have the standalone SDK v2 up and running, we need to replace all old functions for read, import, delete, and create to include the new `Context` field. This is simply to add more information about the error and give the end user a better experience.

One of the functions that has been fully deprecated is `Exists`, this is now checked when a read is hit. This makes sense as we were sorta already doing this anyways.

Next up will be to rewrite the tests as some of these will be deprecated and need further mocking.

Good luck reviewer!