### PR TITLE
[BUGFIX] Re-Add SchemaVersion Argument

### DIFF
--- a/resource_alks_iamrole.go
+++ b/resource_alks_iamrole.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"github.com/Cox-Automotive/alks-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"log"
 	"strings"
 	"time"
@@ -20,6 +22,8 @@ func resourceAlksIamRole() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		SchemaVersion: 1,
+		MigrateState: migrateState,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -72,6 +76,8 @@ func resourceAlksIamTrustRole() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		SchemaVersion: 1,
+		MigrateState: migrateState,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -271,4 +277,29 @@ func updateAlksAccess(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	return nil
+}
+
+func migrateState(version int, state *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch version {
+	case 0:
+		log.Println("[INFO] Found Instance State v0, migrating to v1")
+		return migrateV0toV1(state)
+	default:
+		return state, fmt.Errorf("Unrecognized version '%d' in schema for instance of ALKS IAM role '%s'", version, state.Attributes["name"])
+	}
+}
+
+func migrateV0toV1(state *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if state.Empty() {
+		log.Println("[DEBUG] Empty InstanceState, nothing to migrate")
+		return state, nil
+	}
+
+	if _, ok := state.Attributes["enable_alks_access"]; !ok {
+		log.Printf("[DEBUG] Attributes before migration: %#v", state.Attributes)
+		state.Attributes["enable_alks_access"] = "false"
+		log.Printf("[DEBUG] Attributes after migration: %#v", state.Attributes)
+	}
+
+	return state, nil
 }

--- a/resource_alks_ltk.go
+++ b/resource_alks_ltk.go
@@ -17,7 +17,7 @@ func resourceAlksLtk() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-
+		SchemaVersion: 1,
 		Schema: map[string]*schema.Schema{
 			"iam_username": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
We previously had the `SchemaVersion` set when Terraform was first created to migrate from 0.10 -> 0.11 (I believe it was), and I was under the impression we could remove it since everything was upgraded, but it looks like not. So I'm going to re-add these functions to prevent users from getting errors like the following:

```
│ Error: Resource instance managed by newer provider version
│
│ The current state of module.cloudwatchlogs2splunk_lambda[0].alks_iamrole.lambda_role was created by a newer provider version than is currently selected. Upgrade
│ the alks provider to work with this state.
```

For more information on state migration, see here: https://www.terraform.io/docs/extend/resources/state-migration.html