### PR TITLE
Add Support for darwin/arm64

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.14.x
+        go-version: 1.16.x
 
     - name: Build and Test
       run: make build test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16.x
       - name: Import GPG key
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@v2.1.0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,9 +27,6 @@ builds:
       - '386'
       - arm
       - arm64
-    ignore:
-      - goos: darwin
-        goarch: '386'
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,9 @@ builds:
       - '386'
       - arm
       - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip

--- a/docs/guides/local_installation.md
+++ b/docs/guides/local_installation.md
@@ -47,11 +47,11 @@ mkdir -p ~/.terraform.d/plugins &&
 **One-liner download for macOS / Linux:**
 
 ```sh
-mkdir -p ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.0/darwin_amd64 &&
-      curl -Ls https://api.github.com/repos/Cox-Automotive/terraform-provider-alks/releases | jq -r --arg release "v2.0.0" --arg arch "$(uname -s | tr A-Z a-z)" '.[] | select(.tag_name | contains($release)) | .assets[]| select(.browser_download_url | contains($arch)) | select(.browser_download_url | contains("amd64")) | .browser_download_url' |
-            xargs -n 1 curl -Lo ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.0/darwin_amd64/terraform-provider-alks.zip &&
-      pushd ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.0/darwin_amd64 &&
-      unzip ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.0/darwin_amd64/terraform-provider-alks.zip -d terraform-provider-alks-tmp &&
+mkdir -p ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.4/darwin_amd64 &&
+      curl -Ls https://api.github.com/repos/Cox-Automotive/terraform-provider-alks/releases | jq -r --arg release "v2.0.4" --arg arch "$(uname -s | tr A-Z a-z)" '.[] | select(.tag_name | contains($release)) | .assets[]| select(.browser_download_url | contains($arch)) | select(.browser_download_url | contains("amd64")) | .browser_download_url' |
+            xargs -n 1 curl -Lo ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.4/darwin_amd64/terraform-provider-alks.zip &&
+      pushd ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.4/darwin_amd64 &&
+      unzip ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.4/darwin_amd64/terraform-provider-alks.zip -d terraform-provider-alks-tmp &&
       mv terraform-provider-alks-tmp/terraform-provider-alks* . &&
       chmod +x terraform-provider-alks* &&
       rm -rf terraform-provider-alks-tmp &&

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     alks = {
       source  = "Cox-Automotive/alks"
-      version = "2.0.0"
+      version = "2.0.4"
     }
     aws = {
       source = "hashicorp/aws"


### PR DESCRIPTION
Updates `.goreleaser.yml` file to use a newer version of `go` in order to support `darwin/arm64`. More information on these changes here: https://goreleaser.com/deprecations/#builds-for-darwinarm64

Note: I removed some ignored binaries - I don't think this was intentional. Fixed that up.