### PR TITLE
Update Docs

### DIFF
--- a/docs/guides/local_installation.md
+++ b/docs/guides/local_installation.md
@@ -47,11 +47,11 @@ mkdir -p ~/.terraform.d/plugins &&
 **One-liner download for macOS / Linux:**
 
 ```sh
-mkdir -p ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.4/darwin_amd64 &&
-      curl -Ls https://api.github.com/repos/Cox-Automotive/terraform-provider-alks/releases | jq -r --arg release "v2.0.4" --arg arch "$(uname -s | tr A-Z a-z)" '.[] | select(.tag_name | contains($release)) | .assets[]| select(.browser_download_url | contains($arch)) | select(.browser_download_url | contains("amd64")) | .browser_download_url' |
-            xargs -n 1 curl -Lo ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.4/darwin_amd64/terraform-provider-alks.zip &&
-      pushd ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.4/darwin_amd64 &&
-      unzip ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.4/darwin_amd64/terraform-provider-alks.zip -d terraform-provider-alks-tmp &&
+mkdir -p ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.5/darwin_amd64 &&
+      curl -Ls https://api.github.com/repos/Cox-Automotive/terraform-provider-alks/releases | jq -r --arg release "v2.0.5" --arg arch "$(uname -s | tr A-Z a-z)" '.[] | select(.tag_name | contains($release)) | .assets[]| select(.browser_download_url | contains($arch)) | select(.browser_download_url | contains("amd64")) | .browser_download_url' |
+            xargs -n 1 curl -Lo ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.5/darwin_amd64/terraform-provider-alks.zip &&
+      pushd ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.5/darwin_amd64 &&
+      unzip ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.5/darwin_amd64/terraform-provider-alks.zip -d terraform-provider-alks-tmp &&
       mv terraform-provider-alks-tmp/terraform-provider-alks* . &&
       chmod +x terraform-provider-alks* &&
       rm -rf terraform-provider-alks-tmp &&

--- a/docs/resources/alks_iamtrustrole.md
+++ b/docs/resources/alks_iamtrustrole.md
@@ -22,6 +22,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the IAM role to create. This parameter allows a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-. Role names are not distinguished by case.
 * `type` - (Required) 	The role type to use `Cross Account` or `Inner Account`.
 * `trust_arn` - (Required) Account role ARN to trust.
+  * _Note: This only allows **ONE** account role ARN. This is an intended security control by CAI._
 * `role_added_to_ip` - (Computed) Indicates whether or not an instance profile role was created.
 * `arn` - (Computed) Provides the ARN of the role that was created.
 * `ip_arn` - (Computed) If `role_added_to_ip` was `true` this will provide the ARN of the instance profile role.

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     alks = {
       source  = "Cox-Automotive/alks"
-      version = "2.0.4"
+      version = "2.0.5"
     }
     aws = {
       source = "hashicorp/aws"


### PR DESCRIPTION
- Added a note to the `trust_arn` argument which warns the end user that we only allow ONE trust ARN to be attached to this resource. 