### PR TITLE
Add IAM Role Name Prefix

### DIFF
--- a/docs/resources/alks_iamrole.md
+++ b/docs/resources/alks_iamrole.md
@@ -15,6 +15,22 @@ resource "alks_iamrole" "test_role" {
 }
 ```
 
+This will create a role with the exact name `My_Test_Role`.
+
+### ALKS IAM Role Creation with Name Prefix
+
+```hcl
+resource "alks_iamrole" "test_role" {
+    name_prefix              = "My_Test_Role_"
+    type                     = "Amazon EC2"
+    include_default_policies = false
+    enable_alks_access       = false
+}
+```
+
+This will create a role named similar to `My_Test_Role_20211103145836382400000001`.
+This is useful to avoid name conflicts when using the same terraform in multiple regions.
+
 ### ALKS Dynamic Role Creation
 
 ```hcl
@@ -35,7 +51,8 @@ resource "alks_iamrole" "test_dynamic_role" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the ALKS IAM role which will be reflected in AWS and the ALKS UI.
+* `name` - (Optional/Computed) The name of the ALKS IAM role which will be reflected in AWS and the ALKS UI.
+* `name_prefix` - (Optional/Computed) A prefix for a generated name of the ALKS IAM role which will be reflected in AWS and the ALKS UI.
 * `type` - (Required) The role type to use. To see a list of available roles, [call this endpoint](https://pages.ghe.coxautoinc.com/ETS-CloudAutomation/ALKS-Documentation/#/aws-role-type-rest-service/getAllAwsRoleTypesUsingGET).
 * `include_default_policies` - (Required) Whether or not the default manages policies should be attached to the role.
 * `role_added_to_ip` - (Computed) Indicates whether or not an instance profile role was created.

--- a/docs/resources/alks_iamtrustrole.md
+++ b/docs/resources/alks_iamtrustrole.md
@@ -19,7 +19,8 @@ resource "alks_iamtrustrole" "test_trust_role" {
 ## Argument Reference
 
 The following arguments are supported:
-* `name` - (Required) The name of the IAM role to create. This parameter allows a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-. Role names are not distinguished by case.
+* `name` - (Optional/Computed) The name of the IAM role to create. This parameter allows a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-. Role names are not distinguished by case.
+* `name_prefix` - (Optional/Computed) A prefix for a generated name of the IAM role to create. This parameter allows a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@-. Role names are not distinguished by case.
 * `type` - (Required) 	The role type to use `Cross Account` or `Inner Account`.
 * `trust_arn` - (Required) Account role ARN to trust.
   * _Note: This only allows **ONE** account role ARN. This is an intended security control by CAI._

--- a/naming.go
+++ b/naming.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// NameWithPrefix returns in order:
+// the name if non-empty,
+// a prefix generated name if non-empty,
+// or fully generated name prefixed with "terraform-".
+func NameWithPrefix(name string, namePrefix string) string {
+	if name != "" {
+		return name
+	}
+
+	if namePrefix != "" {
+		return resource.PrefixedUniqueId(namePrefix)
+	}
+
+	return resource.UniqueId()
+}
+
+func NamePrefixFromName(name string) *string {
+	namePrefixIndex := len(name) - resource.UniqueIDSuffixLength
+
+	if namePrefixIndex <= 0 {
+		return nil
+	}
+
+	namePrefix := name[:namePrefixIndex]
+
+	return &namePrefix
+}

--- a/naming_test.go
+++ b/naming_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestNameWithPrefix_Name(t *testing.T) {
+	name := NameWithPrefix("full_name", "")
+	if name != "full_name" {
+		t.Fatalf("NameWithPrefix should return the name when name is present, name was %s", name)
+	}
+}
+
+func TestNameWithPrefix_NameAndPrefix(t *testing.T) {
+	name := NameWithPrefix("full_name", "prefix")
+	if name != "full_name" {
+		t.Fatalf("NameWithPrefix should return the name when name and prefix are present, name was %s", name)
+	}
+}
+
+func TestNameWithPrefix_Prefix(t *testing.T) {
+	r := regexp.MustCompile("prefix_[0-9]{26}")
+	name := NameWithPrefix("", "prefix_")
+	if !r.Match([]byte(name)) {
+		t.Fatalf("NameWithPrefix should return a generated name with prefix when prefix is present, name was %s", name)
+	}
+}
+
+func TestNameWithPrefix_NoNameAndNoPrefix(t *testing.T) {
+	r := regexp.MustCompile("terraform-[0-9]{26}")
+	name := NameWithPrefix("", "")
+	if !r.Match([]byte(name)) {
+		t.Fatalf("NameWithPrefix should return a generated name when prefix is present, name was %s", name)
+	}
+}
+
+func TestNamePrefixFromName_ValidPrefixedName(t *testing.T) {
+	prefix := NamePrefixFromName("test_role_20211103145836382400000001")
+	if *prefix != "test_role_" {
+		t.Fatalf("unexpected name prefix %s", *prefix)
+	}
+}
+
+func TestNamePrefixFromName_InvalidPrefixedName(t *testing.T) {
+	prefix := NamePrefixFromName("test_role")
+	if prefix != nil {
+		t.Fatal("expected prefix to be nil")
+	}
+}

--- a/resource_alks_iamrole.go
+++ b/resource_alks_iamrole.go
@@ -3,12 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
-
 	"github.com/Cox-Automotive/alks-go"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"log"
 )
 
 func resourceAlksIamRole() *schema.Resource {
@@ -24,9 +23,18 @@ func resourceAlksIamRole() *schema.Resource {
 		MigrateState:  migrateState,
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+			},
+			"name_prefix": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
 			},
 			"type": {
 				Type:     schema.TypeString,
@@ -68,7 +76,7 @@ func resourceAlksIamRole() *schema.Resource {
 func resourceAlksIamRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[INFO] ALKS IAM Role Create")
 
-	var roleName = d.Get("name").(string)
+	var roleName = NameWithPrefix(d.Get("name").(string), d.Get("name_prefix").(string))
 	var roleType = d.Get("type").(string)
 	var incDefPol = d.Get("include_default_policies").(bool)
 	var enableAlksAccess = d.Get("enable_alks_access").(bool)
@@ -132,6 +140,7 @@ func resourceAlksIamRoleRead(ctx context.Context, d *schema.ResourceData, meta i
 	log.Printf("[INFO] alks_iamrole.id %v", d.Id())
 
 	_ = d.Set("name", foundRole.RoleName)
+	_ = d.Set("name_prefix", NamePrefixFromName(foundRole.RoleName))
 	_ = d.Set("arn", foundRole.RoleArn)
 	_ = d.Set("ip_arn", foundRole.RoleIPArn)
 	_ = d.Set("enable_alks_access", foundRole.AlksAccess)

--- a/resource_alks_iamrole_test.go
+++ b/resource_alks_iamrole_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/Cox-Automotive/alks-go"
@@ -41,6 +42,31 @@ func TestAccAlksIamRole_Basic(t *testing.T) {
 						"alks_iamrole.foo", "include_default_policies", "false"),
 					resource.TestCheckResourceAttr(
 						"alks_iamrole.foo", "enable_alks_access", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMRole_NamePrefix(t *testing.T) {
+	var resp alks.IamRoleResponse
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAlksIamRoleDestroy(&resp),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlksIamRoleConfigNamePrefix,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"alks_iamrole.nameprefix", "name_prefix", "alks_test_acc_"),
+					resource.TestMatchResourceAttr(
+						"alks_iamrole.nameprefix", "name", regexp.MustCompile("alks_test_acc_[0-9]{26}")),
+					resource.TestCheckResourceAttr(
+						"alks_iamrole.nameprefix", "type", "Amazon EC2"),
+					resource.TestCheckResourceAttr(
+						"alks_iamrole.nameprefix", "include_default_policies", "false"),
 				),
 			},
 		},
@@ -94,5 +120,12 @@ const testAccCheckAlksIamRoleConfigUpdateBasic = `
 		type = "Amazon EC2"
 		include_default_policies = false
 		enable_alks_access = true
+	}
+`
+const testAccCheckAlksIamRoleConfigNamePrefix = `
+  resource "alks_iamrole" "nameprefix" {
+    name_prefix = "alks_test_acc_"
+    type = "Amazon EC2"
+		include_default_policies = false
 	}
 `

--- a/resource_alks_iamrole_test.go
+++ b/resource_alks_iamrole_test.go
@@ -73,6 +73,22 @@ func TestAccIAMRole_NamePrefix(t *testing.T) {
 	})
 }
 
+func TestAccIAMRole_NameAndNamePrefixConflict(t *testing.T) {
+	var resp alks.IamRoleResponse
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAlksIamRoleDestroy(&resp),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckAlksIamRoleConfigNameAndNamePrefixConflict,
+				ExpectError: regexp.MustCompile(".*\"name\": conflicts with name_prefix.*"),
+			},
+		},
+	})
+}
+
 func testAccCheckAlksIamRoleDestroy(role *alks.IamRoleResponse) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*alks.Client)
@@ -124,6 +140,14 @@ const testAccCheckAlksIamRoleConfigUpdateBasic = `
 `
 const testAccCheckAlksIamRoleConfigNamePrefix = `
   resource "alks_iamrole" "nameprefix" {
+    name_prefix = "alks_test_acc_"
+    type = "Amazon EC2"
+		include_default_policies = false
+	}
+`
+const testAccCheckAlksIamRoleConfigNameAndNamePrefixConflict = `
+  resource "alks_iamrole" "nameandnameprefixconflict" {
+    name = "test-role"
     name_prefix = "alks_test_acc_"
     type = "Amazon EC2"
 		include_default_policies = false

--- a/resource_alks_iamtrustrole.go
+++ b/resource_alks_iamtrustrole.go
@@ -25,9 +25,18 @@ func resourceAlksIamTrustRole() *schema.Resource {
 		MigrateState:  migrateState,
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+			},
+			"name_prefix": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
 			},
 			"type": {
 				Type:     schema.TypeString,
@@ -63,7 +72,7 @@ func resourceAlksIamTrustRole() *schema.Resource {
 func resourceAlksIamTrustRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[INFO] ALKS IAM Trust Role Create")
 
-	var roleName = d.Get("name").(string)
+	var roleName = NameWithPrefix(d.Get("name").(string), d.Get("name_prefix").(string))
 	var roleType = d.Get("type").(string)
 	var trustArn = d.Get("trust_arn").(string)
 	var enableAlksAccess = d.Get("enable_alks_access").(bool)

--- a/resource_alks_iamtrustrole_test.go
+++ b/resource_alks_iamtrustrole_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/Cox-Automotive/alks-go"
@@ -40,6 +41,29 @@ func TestAccAlksIamTrustRole_Basic(t *testing.T) {
 	})
 }
 
+func TestAccAlksIamTrustRole_NamePrefix(t *testing.T) {
+	var resp alks.IamRoleResponse
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAlksIamRoleDestroy(&resp),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlksIamTrustRoleConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"alks_iamrole.nameprefix", "name_prefix", "alks_test_acc_"),
+					resource.TestMatchResourceAttr(
+						"alks_iamrole.nameprefix", "name", regexp.MustCompile("alks_test_acc_[0-9]{26}")),
+					resource.TestCheckResourceAttr(
+						"alks_iamtrustrole.bar", "type", "Inner Account"),
+				),
+			},
+		},
+	})
+}
+
 const testAccCheckAlksIamTrustRoleConfigBasic = `
 	resource "alks_iamrole" "foo" {
 		name = "foo"
@@ -66,5 +90,18 @@ const testAccCheckAlksIamTrustRoleConfigUpdateBasic = `
 		type = "Inner Account"
 		trust_arn = "${alks_iamrole.foo.arn}"
 		enable_alks_access = true
+	}
+`
+const testAccCheckAlksIamTrustRoleConfigNamePrefix = `
+	resource "alks_iamrole" "nameprefix_role" {
+		name_prefix = "alks_test_acc_"
+		type = "Amazon EC2"
+		include_default_policies = false
+	}
+
+	resource "alks_iamtrustrole" "name-prefix_trustrole" {
+		name_prefix = "alks_test_acc_"
+		type = "Inner Account"
+		trust_arn = "${alks_iamrole.nameprefix_role.arn}"
 	}
 `


### PR DESCRIPTION
This change will add a `name_prefix` attribute to the `alks_iamrole` and `alks_iamtrustrole` resources. Setting the `name_prefix` will result in a unique, generated role name that begins with the value of `name_prefix`. The generated portion of the name is generated by the Terraform plugin SDK. The functionality is based on the [AWS Terraform provider.](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#name_prefix)

>`name` - (Optional, Forces new resource) Friendly name of the role. If omitted, Terraform will assign a random, unique name. See IAM Identifiers for more information.
>`name_prefix` - (Optional, Forces new resource) Creates a unique friendly name beginning with the specified prefix. Conflicts with name.

This is a non-breaking change, existing usage of `alks_iamrole` and `alks_iamtrustrole` will not be affected by using this version.

The primary reason for making this change is to easily apply a terraform script to multiple regions and not encounter a naming conflict.

[AWS Terraform Provider source](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/iam/role.go)

Fixes #20 