### PR TITLE
Force recreate on max session duration

### DIFF
--- a/docs/guides/local_installation.md
+++ b/docs/guides/local_installation.md
@@ -48,7 +48,7 @@ mkdir -p ~/.terraform.d/plugins &&
 
 ```sh
 mkdir -p ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.5/darwin_amd64 &&
-      curl -Ls https://api.github.com/repos/Cox-Automotive/terraform-provider-alks/releases | jq -r --arg release "v2.5.0" --arg arch "$(uname -s | tr A-Z a-z)" '.[] | select(.tag_name | contains($release)) | .assets[]| select(.browser_download_url | contains($arch)) | select(.browser_download_url | contains("amd64")) | .browser_download_url' |
+      curl -Ls https://api.github.com/repos/Cox-Automotive/terraform-provider-alks/releases | jq -r --arg release "v2.5.1" --arg arch "$(uname -s | tr A-Z a-z)" '.[] | select(.tag_name | contains($release)) | .assets[]| select(.browser_download_url | contains($arch)) | select(.browser_download_url | contains("amd64")) | .browser_download_url' |
             xargs -n 1 curl -Lo ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.5/darwin_amd64/terraform-provider-alks.zip &&
       pushd ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.5/darwin_amd64 &&
       unzip ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.0.5/darwin_amd64/terraform-provider-alks.zip -d terraform-provider-alks-tmp &&

--- a/docs/resources/alks_iamrole.md
+++ b/docs/resources/alks_iamrole.md
@@ -100,7 +100,7 @@ The following arguments are supported:
 * `enable_alks_access` - (Optional) If `true`, allows ALKS calls to be made by instance profiles or Lambda functions making use of this role. Note: This enables **machine identity** capability.
 * `template_fields` - (Optional) If present, will submit template field data to ALKS.  Note: This will generate an error if the role type does not support template fields.
 * `tags` - (Optional) If present, will add specified tags onto role.
-* `max_session_duration_in_seconds` - (Optional) If present, will set maximum duration for role 
+* `max_session_duration_in_seconds` - (Optional) If present, will set maximum duration for role. Change forces re-creation of resource.
 
 ## Import
 

--- a/docs/resources/alks_iamtrustrole.md
+++ b/docs/resources/alks_iamtrustrole.md
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `ip_arn` - (Computed) If `role_added_to_ip` was `true` this will provide the ARN of the instance profile role.
 * `enable_alks_access` - (Optional) If `true`, allows ALKS calls to be made by instance profiles or Lambda functions making use of this role. Note: This enables **machine identity** capability.
 * `tags` - (Optional) If present, will add specified tags onto role. 
-* `max_session_duration_in_seconds` - (Optional) If present, will set maximum duration for role 
+* `max_session_duration_in_seconds` - (Optional) If present, will set maximum duration for role. Change forces re-creation of resource.
 
 
 ## Import

--- a/resource_alks_iamrole.go
+++ b/resource_alks_iamrole.go
@@ -87,6 +87,7 @@ func resourceAlksIamRole() *schema.Resource {
 				Type:     schema.TypeInt,
 				Default:  3600,
 				Optional: true,
+				ForceNew: true,
 			},
 			"tags":     TagsSchema(),
 			"tags_all": TagsSchemaComputed(),

--- a/resource_alks_iamtrustrole.go
+++ b/resource_alks_iamtrustrole.go
@@ -71,6 +71,7 @@ func resourceAlksIamTrustRole() *schema.Resource {
 				Type:     schema.TypeInt,
 				Default:  3600,
 				Optional: true,
+				ForceNew: true,
 			},
 			"tags":     TagsSchema(),
 			"tags_all": TagsSchemaComputed(),


### PR DESCRIPTION
# Description

Changed max_session_duration_in_seconds to force a re-create upon modification because it is not currently supported in ALKS Core update endpoints. 

Rally # [DE276999](https://rally1.rallydev.com/#/?detail=/defect/644888875133&fdp=true): ALKS TFP:  Changing max duration in seconds doesn't work.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

## Steps:
  1. Acceptance Tests
  2. Manual Local Testing