### PR TITLE
Alks error

### DIFF
--- a/docs/guides/local_installation.md
+++ b/docs/guides/local_installation.md
@@ -47,11 +47,11 @@ mkdir -p ~/.terraform.d/plugins &&
 **One-liner download for macOS / Linux:**
 
 ```sh
-mkdir -p ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.6.0/darwin_amd64 &&
-      curl -Ls https://api.github.com/repos/Cox-Automotive/terraform-provider-alks/releases | jq -r --arg release "v2.5.1" --arg arch "$(uname -s | tr A-Z a-z)" '.[] | select(.tag_name | contains($release)) | .assets[]| select(.browser_download_url | contains($arch)) | select(.browser_download_url | contains("amd64")) | .browser_download_url' |
-            xargs -n 1 curl -Lo ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.6.0/darwin_amd64/terraform-provider-alks.zip &&
-      pushd ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.6.0/darwin_amd64 &&
-      unzip ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.6.0/darwin_amd64/terraform-provider-alks.zip -d terraform-provider-alks-tmp &&
+mkdir -p ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.6.1/darwin_amd64 &&
+      curl -Ls https://api.github.com/repos/Cox-Automotive/terraform-provider-alks/releases | jq -r --arg release "v2.6.1" --arg arch "$(uname -s | tr A-Z a-z)" '.[] | select(.tag_name | contains($release)) | .assets[]| select(.browser_download_url | contains($arch)) | select(.browser_download_url | contains("amd64")) | .browser_download_url' |
+            xargs -n 1 curl -Lo ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.6.1/darwin_amd64/terraform-provider-alks.zip &&
+      pushd ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.6.1/darwin_amd64 &&
+      unzip ~/.terraform.d/plugins/Cox-Automotive/engineering-enablement/alks/2.6.1/darwin_amd64/terraform-provider-alks.zip -d terraform-provider-alks-tmp &&
       mv terraform-provider-alks-tmp/terraform-provider-alks* . &&
       chmod +x terraform-provider-alks* &&
       rm -rf terraform-provider-alks-tmp &&

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Use the navigation to the left to read about the available resources.
 # Configure the ALKS Terraform Provider
 provider "alks" {
     url     = "https://alks.foo.com/rest"
-    version = ">= 2.2.0"
+    version = ">= 2.6.0"
 }
 
 # Create an ALKS IAM role
@@ -35,7 +35,7 @@ Static credentials can be provided via an `access_key`, `secret_key` and `token`
 ```hcl
 provider "alks" {
     url        = "https://alks.foo.com/rest"
-    version    = ">= 2.2.0"
+    version    = ">= 2.6.0"
     access_key = "accesskey"
     secret_key = "secretkey"
     token      = "sessiontoken"
@@ -49,7 +49,7 @@ Terraform file:
 ```hcl
 provider "alks" {
     url     = "https://alks.foo.com/rest"
-    version = ">= 2.2.0"
+    version = ">= 2.6.0"
 }
 ```
 
@@ -68,7 +68,7 @@ You can use an AWS credentials file to specify your credentials. The default loc
 ```hcl
 provider "alks" {
     url                     = "https://alks.foo.com/rest"
-    version                 = ">= 2.2.0"
+    version                 = ">= 2.6.0"
     shared_credentials_file = "/Users/my_user/.aws/credentials"
     profile                 = "foo"
 }
@@ -86,7 +86,7 @@ Your ALKS provider block can look just like this:
 ```hcl
 provider "alks" {
     url     = "https://alks.foo.com/rest"
-    version = ">= 2.2.0"
+    version = ">= 2.6.0"
 }
 ```
 
@@ -95,7 +95,7 @@ Since Machine Identities work with Instance Profile Metadata directly, it can be
 ```hcl
 provider "alks" {
    url     = "https://alks.foo.com/rest"
-   version = ">= 2.2.0"
+   version = ">= 2.6.0"
    assume_role {
       role_arn = "arn:aws:iam::112233445566:role/acct-managed/JenkinsPRODAccountTrust"
    }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Cox-Automotive/terraform-provider-alks
 go 1.18
 
 require (
-	github.com/Cox-Automotive/alks-go v0.0.0-20221004204541-a25fb5c4f655
+	github.com/Cox-Automotive/alks-go v0.0.0-20221010204605-136b6e9b6530
 	github.com/aws/aws-sdk-go v1.31.15
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.21.0
 	github.com/mitchellh/go-homedir v1.1.0
@@ -57,3 +57,4 @@ require (
 	google.golang.org/grpc v1.48.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
+

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/Cox-Automotive/alks-go v0.0.0-20221003153830-68567ef62d72 h1:tubP3IYG
 github.com/Cox-Automotive/alks-go v0.0.0-20221003153830-68567ef62d72/go.mod h1:jJNgXthl59Vt2tJHSC3WZ0vlopV9xqdclfQuLgwHjOw=
 github.com/Cox-Automotive/alks-go v0.0.0-20221004204541-a25fb5c4f655 h1:akQkFItS/++rMakX7rbK70ouYTG0Q6vxUqxvfzBZ9Wg=
 github.com/Cox-Automotive/alks-go v0.0.0-20221004204541-a25fb5c4f655/go.mod h1:jJNgXthl59Vt2tJHSC3WZ0vlopV9xqdclfQuLgwHjOw=
+github.com/Cox-Automotive/alks-go v0.0.0-20221010204605-136b6e9b6530 h1:8j3NYoLnFy2PGw+UX47C8jC2j3CCkFeXqlaMfKu9Bh8=
+github.com/Cox-Automotive/alks-go v0.0.0-20221010204605-136b6e9b6530/go.mod h1:jJNgXthl59Vt2tJHSC3WZ0vlopV9xqdclfQuLgwHjOw=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=

--- a/resource_alks_iamrole.go
+++ b/resource_alks_iamrole.go
@@ -152,7 +152,7 @@ func resourceAlksIamRoleCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	resp, err := client.CreateIamRole(options)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(err.Err)
 	}
 
 	d.SetId(resp.RoleName)
@@ -173,7 +173,7 @@ func resourceAlksIamRoleDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if err := client.DeleteIamRole(d.Id()); err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(err.Err)
 	}
 
 	return nil
@@ -195,16 +195,13 @@ func resourceAlksIamRoleRead(ctx context.Context, d *schema.ResourceData, meta i
 	foundRole, err := client.GetIamRole(d.Id())
 
 	if err != nil {
-		// If 404 Role not found error, an error and a role with Exists field set to false will come back from alks-go
-		// We will log ther error and set id to "" and return nil, letting terraform decide how to handle role not found.
-		if foundRole != nil {
-			if foundRole.Exists != true {
-				log.Printf("[Error] %s", err)
-				d.SetId("")
-				return nil
-			}
+		//If error is 404, RoleNotFound, we log it and let terraform decide how to handle it.
+		//All other errors cause a failure
+		if err.StatusCode == 404 {
+			log.Printf("[Error] %s", err.Err)
+			d.SetId("")
+			return nil
 		}
-		d.SetId("")
 		return diag.FromErr(err)
 	}
 
@@ -285,13 +282,13 @@ func updateAlksAccess(d *schema.ResourceData, meta interface{}) error {
 	if alksAccess {
 		_, err := client.AddRoleMachineIdentity(roleArn)
 		if err != nil {
-			return err
+			return err.Err
 		}
 	} else {
 		// delete the machine identity
 		_, err := client.DeleteRoleMachineIdentity(roleArn)
 		if err != nil {
-			return err
+			return err.Err
 		}
 	}
 	return nil
@@ -310,7 +307,7 @@ func updateIamTags(d *schema.ResourceData, meta interface{}) error {
 	foundRole, err := client.GetIamRole(d.Id())
 
 	if err != nil {
-		return err
+		return err.Err
 	}
 
 	existingTags := tagSliceToMap(foundRole.Tags)
@@ -326,7 +323,7 @@ func updateIamTags(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if _, err := client.UpdateIamRole(&options); err != nil {
-		return err
+		return err.Err
 	}
 	return nil
 }

--- a/resource_alks_iamtrustrole.go
+++ b/resource_alks_iamtrustrole.go
@@ -114,7 +114,7 @@ func resourceAlksIamTrustRoleCreate(ctx context.Context, d *schema.ResourceData,
 		resp, err = client.CreateIamTrustRole(options)
 		if err != nil {
 			if strings.Contains(err.Error(), "Role already exists") || strings.Contains(err.Error(), "Instance profile exists") {
-				return resource.NonRetryableError(err)
+				return resource.NonRetryableError(err.Err)
 			}
 
 			// Amazon IAM utilizes an eventual consistency model:

--- a/resource_alks_iamtrustrole.go
+++ b/resource_alks_iamtrustrole.go
@@ -101,7 +101,7 @@ func resourceAlksIamTrustRoleCreate(ctx context.Context, d *schema.ResourceData,
 
 	var resp *alks.IamRoleResponse
 	err := resource.RetryContext(ctx, 2*time.Minute, func() *resource.RetryError {
-		var err error
+		var err *alks.AlksError
 
 		options := &alks.CreateIamRoleOptions{
 			RoleName:                    &roleName,

--- a/vendor/github.com/Cox-Automotive/alks-go/alks_error.go
+++ b/vendor/github.com/Cox-Automotive/alks-go/alks_error.go
@@ -1,0 +1,28 @@
+package alks
+
+import (
+	"fmt"
+)
+
+type AlksError struct {
+	StatusCode int
+	RequestId  string `json:"requestId"`
+	Err        error
+}
+
+func (r *AlksError) Error() string {
+	return fmt.Sprintf("status %d: requestID %s: err %v", r.StatusCode, r.RequestId, r.Err)
+}
+
+type AlksResponseError struct {
+	StatusMessage string   `json:"statusMessage"`
+	Errors        []string `json:"errors"`
+	RequestId     string   `json:"requestId"`
+}
+
+var ErrorStringFull = "[%s] ALKS Error %d Msg: %s\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
+var ErrorStringNoReqId = "ALKS Error %d Msg: %s\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
+var ErrorStringOnlyCodeAndReqId = "[%s] ALKS Error %d\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
+var ErrorStringOnlyCode = "ALKS Error %d\n Contact the ALKS Team for assistance on Slack at #alks-client-support"
+var ParseErrorReqId = "[%s] Error parsing ALKS Error response: %s"
+var ParseError = "Error parsing ALKS Error response: %s"

--- a/vendor/github.com/Cox-Automotive/alks-go/api.go
+++ b/vendor/github.com/Cox-Automotive/alks-go/api.go
@@ -190,7 +190,7 @@ func (c *Client) Durations() ([]int, error) {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		durationErr := new(AlksError)
+		durationErr := new(AlksResponseError)
 		err = decodeBody(resp, &durationErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {

--- a/vendor/github.com/Cox-Automotive/alks-go/iam_ltk.go
+++ b/vendor/github.com/Cox-Automotive/alks-go/iam_ltk.go
@@ -90,7 +90,7 @@ func (c *Client) GetLongTermKeys() (*GetLongTermKeysResponse, error) {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		keyErr := new(AlksError)
+		keyErr := new(AlksResponseError)
 		err = decodeBody(resp, &keyErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {
@@ -167,7 +167,7 @@ func (c *Client) GetLongTermKey(iamUsername string) (*GetLongTermKeyResponse, er
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		keyErr := new(AlksError)
+		keyErr := new(AlksResponseError)
 		err = decodeBody(resp, &keyErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {
@@ -235,7 +235,7 @@ func (c *Client) CreateLongTermKey(iamUsername string) (*CreateLongTermKeyRespon
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		keyErr := new(AlksError)
+		keyErr := new(AlksResponseError)
 		err = decodeBody(resp, &keyErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {
@@ -305,7 +305,7 @@ func (c *Client) DeleteLongTermKey(iamUsername string) (*DeleteLongTermKeyRespon
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		keyErr := new(AlksError)
+		keyErr := new(AlksResponseError)
 		err = decodeBody(resp, &keyErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {

--- a/vendor/github.com/Cox-Automotive/alks-go/is_iam_enabled.go
+++ b/vendor/github.com/Cox-Automotive/alks-go/is_iam_enabled.go
@@ -51,7 +51,7 @@ func (c *Client) IsIamEnabled(roleArn string) (*IsIamEnabledResponse, error) {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		iamErr := new(AlksError)
+		iamErr := new(AlksResponseError)
 		err = decodeBody(resp, &iamErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {

--- a/vendor/github.com/Cox-Automotive/alks-go/login_role.go
+++ b/vendor/github.com/Cox-Automotive/alks-go/login_role.go
@@ -25,7 +25,7 @@ func (c *Client) GetMyLoginRole() (*LoginRoleResponse, error) {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		loginErr := new(AlksError)
+		loginErr := new(AlksResponseError)
 		err = decodeBody(resp, &loginErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {
@@ -98,7 +98,7 @@ func (c *Client) GetLoginRole() (*LoginRoleResponse, error) {
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		loginErr := new(AlksError)
+		loginErr := new(AlksResponseError)
 		err = decodeBody(resp, &loginErr)
 		if err != nil {
 			if reqID := GetRequestID(resp); reqID != "" {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/Cox-Automotive/alks-go v0.0.0-20221004204541-a25fb5c4f655
+# github.com/Cox-Automotive/alks-go v0.0.0-20221010204605-136b6e9b6530
 ## explicit; go 1.16
 github.com/Cox-Automotive/alks-go
 # github.com/agext/levenshtein v1.2.2


### PR DESCRIPTION
# Description

Refactor alks_iamrole and alks_iamtrustrole to use new AlksError returned from the new version on alks-go, which has also  been updated. 

Rally # [DE286403](https://rally1.rallydev.com/#/?detail=/defect/659072671783&fdp=true): ALKS Go - Refactor to use new AlksError

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

## Steps:
  1. Unit tests
  2. Manual Tests

# Checklist / To Do:

- [ ] Push new tag
- [ ] Cut release
