### PR TITLE
Add alks_session data source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ gpg/
 
 # ignore. For testing we don't want to store a specific provider.
 .terraform.lock.hcl
+
+# Ignore asdf tool files
+.tool-versions

--- a/data_source_alks_session.go
+++ b/data_source_alks_session.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"github.com/Cox-Automotive/alks-go"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAlksSession() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAlksSessionRead,
+		Schema: map[string]*schema.Schema{
+			"access_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"secret_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"session_token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAlksSessionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerStruct := meta.(*AlksClient)
+	client := providerStruct.client
+	credentials := client.Credentials.(interface{})
+
+	stsCredentials, ok := credentials.(alks.STS)
+
+	if ok {
+		_ = d.Set("access_key", stsCredentials.AccessKey)
+		_ = d.Set("secret_key", stsCredentials.SecretKey)
+		_ = d.Set("session_token", stsCredentials.SessionToken)
+	}
+
+	return nil
+}

--- a/docs/data-sources/alks_session.md
+++ b/docs/data-sources/alks_session.md
@@ -1,0 +1,26 @@
+# Data Source: alks_session
+
+Surfaces the AWS STS Credentials currently in use by the ALKS provider. Unlike the `alks_keys` data source, this data source does not
+generate new credentials on-demand and instead outputs the credentials that the provider is already using.
+
+## Example Usage
+
+```hcl
+data "alks_session" "current" {
+   providers: alks.my_alias
+}
+```
+
+## Argument Reference
+
+* Note: This does not take any arguments. See below.
+
+## Attribute Reference
+
+* `access_key` - Current access key for the specified provider. If multiple providers, it takes the `provider` field. Otherwise, uses the initial provider.
+* `secret_key` - Current secret key for the specified provider. If multiple providers, it takes the `provider` field. Otherwise, uses the initial provider.
+* `session_token` - Current session token for the specified provider. If multiple providers, it takes the `provider` field. Otherwise, uses the initial provider.
+
+
+## How it works 
+- Whatever your default provider credentials are, will be used. If multiple providers have been configured, then one can point the data source to return keys for specific providers using `providers` field with an explicit alias.

--- a/docs/guides/running_in_debugger.md
+++ b/docs/guides/running_in_debugger.md
@@ -1,0 +1,73 @@
+Steps for local TFP development:
+1. Modify the code in the local terraform provider to run in debug mode.  Edit main.go:
+```package main
+import (
+	"flag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+)
+
+func main() {
+	// For debugging provider, set the following environment variable
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	plugin.Serve(&plugin.ServeOpts{
+		Debug: debug,
+		ProviderAddr: "cox-automotive/alks",
+		ProviderFunc: func() *schema.Provider {
+			return Provider()
+		},
+	})
+}
+```
+2.  Modify `~/.terraformrc` and configure dev_overrides to point to your code:
+   ```provider_installation {
+  dev_overrides {
+    "cox-automotive/alks" = "/Users/james.barcelo/code/github.com/jcarlson/terraform-provider-alks"
+   }
+
+  direct {}
+}
+
+```
+3.  Build local TFP in root dir (where the dev_override points):
+   `cd ~/code/github.com/jcarlson/terraform-provider-alks && go build -o terraform-provider-alks -gcflags '-N -l'`
+4. Setup launch.json config in vscode.  Note the args array uses your new debug flag:
+```
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug ALKS TFP in local repo",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}",
+            "env": {},
+            "args": [
+                "-debug"
+            ],
+            "envFile": "${workspaceFolder}/.vscode/private.env"
+        }
+    ]
+}
+```
+5. Setup private.env as referenced in launch.json:
+```
+AWS_ACCESS_KEY_ID=ASIA3XTHISISPUBLICDATA
+AWS_SECRET_ACCESS_KEY=KEEPITSECRET
+AWS_SESSION_TOKEN=KEEPITSAFE
+```
+5. Run the launch config and then click on the "DEBUG CONSOLE".  You should see something like this:
+```
+TF_REATTACH_PROVIDERS='{"cox-automotive/alks":{"Protocol":"grpc","ProtocolVersion":5,"Pid":98763,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/jq/g4z2vsvn77s0c49s3zvk4cgw0000gq/T/plugin3567641228"}}}'
+```
+This means your custom provider is running and ready for connections.  Terraform connects with providers over grpc so the provider will run in server debug mode until you stop it.  You don't have to restart after every terraform run.
+6. In seperate console run your terraform prefaced with the above environment variables:
+```
+TF_REATTACH_PROVIDERS='{"cox-automotive/alks":{"Protocol":"grpc","ProtocolVersion":5,"Pid":98763,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/jq/g4z2vsvn77s0c49s3zvk4cgw0000gq/T/plugin3567641228"}}}' terraform apply
+```
+7. If you did everything right it is highly likely you will be able to successfully set breakpoints in vscode.

--- a/examples/alks_session_example/main.tf
+++ b/examples/alks_session_example/main.tf
@@ -1,0 +1,88 @@
+terraform {
+  required_version = "~> 1.5"
+
+  required_providers {
+    alks = {
+      source  = "cox-automotive/alks"
+      #source  = "terraformLocal/alks"
+      #source = "/Users/james.barcelo/code/github.com/jcarlson/terraform-provider-alks"
+      #version = "~> 2.8"
+    }
+
+    shell = {
+      source  = "scottwinkler/shell"
+      version = "~> 1.7"
+    }
+  }
+}
+
+provider "alks" {
+  url = "https://alks.coxautoinc.com/rest"
+
+  ignore_tags {
+    key_prefixes = ["cai:catalog"]
+  }
+}
+
+data "alks_keys" "session" {
+}
+
+data "alks_session" "current" {
+}
+
+resource "shell_script" "sts_identity" {
+  environment = {
+    AWS_REGION = "us-east-1"
+  }
+
+  sensitive_environment = {
+    AWS_ACCESS_KEY_ID     = data.alks_session.current.access_key
+    AWS_SECRET_ACCESS_KEY = data.alks_session.current.secret_key
+    AWS_SESSION_TOKEN     = data.alks_session.current.session_token
+  }
+
+  lifecycle_commands {
+    create = "aws sts get-caller-identity"
+    delete = ""
+  }
+
+  lifecycle {
+    ignore_changes = [
+      sensitive_environment["AWS_ACCESS_KEY_ID"],
+      sensitive_environment["AWS_SECRET_ACCESS_KEY"],
+      sensitive_environment["AWS_SESSION_TOKEN"]
+    ]
+  }
+}
+
+output "user_id" {
+  value = shell_script.sts_identity.output["UserId"]
+}
+
+output "arn" {
+  value = shell_script.sts_identity.output["Arn"]
+}
+
+output "alks_session_access_key" {
+  value = data.alks_session.current.access_key
+}
+
+output "alks_session_secret_key" {
+  value = data.alks_session.current.secret_key
+  sensitive = true
+
+}
+
+output "alks_session_session_token" {
+  value = data.alks_session.current.session_token
+  sensitive = true
+}
+
+output "alks_keys_access_key" {
+  value = data.alks_keys.session.access_key
+}
+
+output "alks_keys_secret_key" {
+  value = data.alks_keys.session.secret_key
+}
+  

--- a/main.go
+++ b/main.go
@@ -1,12 +1,21 @@
 package main
 
 import (
+	"flag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
 func main() {
+	// For debugging provider, set the following environment variable
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
 	plugin.Serve(&plugin.ServeOpts{
+		Debug:        debug,
+		ProviderAddr: "cox-automotive/alks",
 		ProviderFunc: func() *schema.Provider {
 			return Provider()
 		},

--- a/provider.go
+++ b/provider.go
@@ -86,7 +86,8 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"alks_keys": dataSourceAlksKeys(),
+			"alks_keys":    dataSourceAlksKeys(),
+			"alks_session": dataSourceAlksSession(),
 		},
 
 		ConfigureContextFunc: providerConfigure,


### PR DESCRIPTION
## Change Log Items

* Adds a new data source provider, `alks_session`

## Description

The new data source, `alks_session`, surfaces the AWS STS credentials that the `alks` provider is configured with