### PR TITLE
Defect duplicate tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ build:
 test:
 	go test -timeout 1200s -v .
 
+testacc:
+	TF_ACC=1 go test -timeout 1200s -v . $(TESTARGS)
+
 plan:
 	@terraform plan
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ test:
 	go test -timeout 1200s -v .
 
 testacc:
+	@echo "set TESTARGS=\"-run TestAccXXX\" to run individual tests"
 	TF_ACC=1 go test -timeout 1200s -v . $(TESTARGS)
 
 plan:

--- a/resource_alks_iamrole.go
+++ b/resource_alks_iamrole.go
@@ -7,7 +7,6 @@ import (
 	"log"
 
 	"github.com/Cox-Automotive/alks-go"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -233,21 +232,9 @@ func resourceAlksIamRoleRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	// roleSpecificTags := localTags
-	tflog.Debug(ctx, "show raw data", map[string]interface{}{
-		"raw_config": d.GetRawConfig(),
-		"raw_plan":   d.GetRawPlan(),
-		"raw_state":  d.GetRawState(),
-	})
-
 	if err := d.Set("tags", removeIgnoredTags(resolveDuplicates(allTags, defaultTags, d), *ignoreTags)); err != nil {
 		return diag.FromErr(err)
 	}
-
-	// TODO: In the future, our API or tags need to dynamically grab these values.
-	//  Till then, all imports require a destroy + create.
-	//_ = d.Set("type", foundrole.RoleType)
-	//_ = d.Set("include_default_policies", foundrole.InclDefaultPolicies)
 
 	return nil
 }

--- a/resource_alks_iamrole.go
+++ b/resource_alks_iamrole.go
@@ -7,6 +7,7 @@ import (
 	"log"
 
 	"github.com/Cox-Automotive/alks-go"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -232,9 +233,14 @@ func resourceAlksIamRoleRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	roleSpecificTags := removeDefaultTags(localTags, defaultTags)
+	// roleSpecificTags := localTags
+	tflog.Debug(ctx, "show raw data", map[string]interface{}{
+		"raw_config": d.GetRawConfig(),
+		"raw_plan":   d.GetRawPlan(),
+		"raw_state":  d.GetRawState(),
+	})
 
-	if err := d.Set("tags", roleSpecificTags); err != nil {
+	if err := d.Set("tags", removeIgnoredTags(resolveDuplicates(allTags, defaultTags, d), *ignoreTags)); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
## Change Log Items

* Fixes a bug that ignores resource `tags` if the key-value pair also exists in `default_tags`

## Description

Adds a `ResolveDuplicates` function to check for tags from terraform's configuration along with tags retrieved directly from AWS. Most of the code was taken from this PR: https://github.com/hashicorp/terraform-provider-aws/pull/30793, removing interceptor code not relevant to the ALKS provider

## Acceptance Tests Results
```
➜ make testacc TESTARGS="-run TestAccAlksIamRole"                                 

TF_ACC=1 go test -timeout 1200s -v . -run TestAccAlksIamRole
=== RUN   TestAccAlksIamRole_Basic
--- PASS: TestAccAlksIamRole_Basic (45.98s)
=== RUN   TestAccAlksIamRole_Tags
--- PASS: TestAccAlksIamRole_Tags (43.11s)
=== RUN   TestAccAlksIamRole_DefaultTags_TrustPolicy
--- PASS: TestAccAlksIamRole_DefaultTags_TrustPolicy (47.72s)
=== RUN   TestAccAlksIamRole_DefaultTags_TrustPolicyUpdate
--- PASS: TestAccAlksIamRole_DefaultTags_TrustPolicyUpdate (46.29s)
=== RUN   TestAccAlksIamRole_DefaultTags_RoleType
--- PASS: TestAccAlksIamRole_DefaultTags_RoleType (43.01s)
=== RUN   TestAccAlksIamRole_DefaultTagsEmpty
--- PASS: TestAccAlksIamRole_DefaultTagsEmpty (35.28s)
=== RUN   TestAccAlksIamRole_DefaultTagSameAsResourceTag
--- PASS: TestAccAlksIamRole_DefaultTagSameAsResourceTag (43.47s)
=== RUN   TestAccAlksIamRole_IgnoreTagsEmpty
--- PASS: TestAccAlksIamRole_IgnoreTagsEmpty (43.41s)
=== RUN   TestAccAlksIamRole_IgnoreTags
--- PASS: TestAccAlksIamRole_IgnoreTags (35.24s)
=== RUN   TestAccAlksIamRole_NoMaxDuration
--- PASS: TestAccAlksIamRole_NoMaxDuration (44.34s)
PASS
ok      github.com/Cox-Automotive/terraform-provider-alks       427.845s

```

#### Rally: [DE379216](https://rally1.rallydev.com/#/?detail=/defect/730800291585&fdp=true): ALKS Terraform provider defect