### PR TITLE
Updating docs to make type and assume_role_policy use more clear.

### DIFF
--- a/docs/resources/alks_iamrole.md
+++ b/docs/resources/alks_iamrole.md
@@ -92,7 +92,8 @@ The following arguments are supported:
 
 * `name` - (Optional/Computed) The name of the ALKS IAM role which will be reflected in AWS and the ALKS UI.
 * `name_prefix` - (Optional/Computed) A prefix for a generated name of the ALKS IAM role which will be reflected in AWS and the ALKS UI.
-* `type` - (Required) The role type to use. To see a list of available roles, [call this endpoint](https://pages.ghe.coxautoinc.com/ETS-CloudAutomation/ALKS-Documentation/#/aws-role-type-rest-service/getAllAwsRoleTypesUsingGET).
+* `type` - (Required) The role type to use.  This argument is mutually exclusive with `assume_role_policy`. To see a list of available roles, [call this endpoint](https://pages.ghe.coxautoinc.com/ETS-CloudAutomation/ALKS-Documentation/#/aws-role-type-rest-service/getAllAwsRoleTypesUsingGET).
+* `assume_role_policy` - (Required) A JSON string representing the trust policy for the role. This is only supported for single-service trust policies trusting an approved AWS service.  This argument is mutually exclusive with `type`.
 * `include_default_policies` - (Required) Whether or not the default manages policies should be attached to the role.
 * `role_added_to_ip` - (Computed) Indicates whether or not an instance profile role was created.
 * `arn` - (Computed) Provides the ARN of the role that was created.

--- a/docs/resources/alks_iamrole.md
+++ b/docs/resources/alks_iamrole.md
@@ -92,8 +92,8 @@ The following arguments are supported:
 
 * `name` - (Optional/Computed) The name of the ALKS IAM role which will be reflected in AWS and the ALKS UI.
 * `name_prefix` - (Optional/Computed) A prefix for a generated name of the ALKS IAM role which will be reflected in AWS and the ALKS UI.
-* `type` - (Required) The role type to use.  This argument is mutually exclusive with `assume_role_policy`. To see a list of available roles, [call this endpoint](https://pages.ghe.coxautoinc.com/ETS-CloudAutomation/ALKS-Documentation/#/aws-role-type-rest-service/getAllAwsRoleTypesUsingGET).
-* `assume_role_policy` - (Required) A JSON string representing the trust policy for the role. This is only supported for single-service trust policies trusting an approved AWS service.  This argument is mutually exclusive with `type`.
+* `type` - (Optional) The role type to use. To see a list of available roles, [call this endpoint](https://pages.ghe.coxautoinc.com/ETS-CloudAutomation/ALKS-Documentation/#operation/getAllAwsRoleTypes). Exactly one of `type` or `assume_role_policy` must be specified.
+* `assume_role_policy` - (Optional) A JSON string representing the trust policy for the role. This is only supported for single-service trust policies trusting an approved AWS service. Exactly one of `type` or `assume_role_policy` must be specified.
 * `include_default_policies` - (Required) Whether or not the default manages policies should be attached to the role.
 * `role_added_to_ip` - (Computed) Indicates whether or not an instance profile role was created.
 * `arn` - (Computed) Provides the ARN of the role that was created.


### PR DESCRIPTION


## Change Log Items

* Update argument text in docs out the mutual exclusiveness of required arguments type and assume_role_policy

## Description

When using alks_iamrole users should either specify type or assume_role_policy.  Not both but must use one.

#### Rally: 
[DE431382](https://rally1.rallydev.com/#/?detail=/defect/776181079453&fdp=true): ALKS TF provider: Role Type is mandatory